### PR TITLE
ci: auto-sync package.json after release via peter-evans PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,47 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # After a successful publish, open a PR that brings package.json files
+  # on main in step with the released version. Lets us tag without a manual
+  # bump — the catchup PR is squash-merged with one click. peter-evans/
+  # create-pull-request is idempotent: re-running on the same version updates
+  # the existing branch instead of creating a duplicate.
+  sync-package-json:
+    needs: publish-npm
+    if: needs.publish-npm.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Bump package.json files to released version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          cd server && npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Open catchup PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "chore(release): sync package.json to ${{ github.ref_name }}"
+          commit-message: "chore(release): sync package.json to ${{ github.ref_name }}"
+          branch: release-sync/${{ github.ref_name }}
+          base: main
+          labels: release-sync
+          body: |
+            Automated catchup — `${{ github.ref_name }}` has been published to npm.
+            This PR brings `package.json` (root + server) on `main` in step with
+            the released version. Safe to squash-merge.
+
+            See `docs/wiki/` if regeneration is needed; this PR only touches versions.
+          delete-branch: true


### PR DESCRIPTION
## Summary

After a successful npm publish, open a catchup PR that bumps `package.json` (root + server) on `main` to match the released tag. Drops the manual "bump before tagging" step from the release ritual.

## Why peter-evans vs. direct push

A direct push to `main` would need:
- Branch-protection bypass
- `[skip ci]` guard against infinite loops
- Signed-commit / token handling

peter-evans/create-pull-request sidesteps all three by going through a PR. The PR is idempotent — re-running for the same tag updates the existing branch instead of opening a duplicate.

## Lifecycle

1. You tag `v0.X.Y` from any state of `main`.
2. Release workflow publishes (uses `--allow-same-version` so a stale `package.json` doesn't fail the publish).
3. New `sync-package-json` job opens PR `release-sync/v0.X.Y`.
4. Squash-merge with one click — `main` is in step with the released version.

Net effect: stop manually bumping `package.json` before tagging. Tag whatever you want released; CI handles the catchup.

## Alternatives considered

- **Pre-flight assertion** (fail release if tag ≠ package.json): fails fast but still requires a manual bump.
- **release-please / semantic-release**: more comprehensive but bigger rewrite, requires conventional-commit discipline.

## Test plan

- [ ] Tag `v0.14.1` (or next release) and verify the sync PR opens
- [ ] Squash-merge the sync PR and confirm `main`'s `package.json` matches
- [ ] Tag again with the SAME version (manual scenario) and verify peter-evans treats it as no-op (no duplicate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)