### PR TITLE
chore(release): sync package.json to v0.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain",
-  "version": "0.12.1",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain",
-      "version": "0.12.1",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "description": "Digital brain as skills for AI coding CLIs — no vector DB, no embeddings, no infrastructure",
   "keywords": [

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.3.1",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain-server",
-      "version": "0.3.1",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "description": "SQLite FTS5 search server for wicked-brain digital knowledge bases",
   "keywords": [


### PR DESCRIPTION
Automated catchup — `v0.14.1` has been published to npm. This PR brings `package.json` (root + server) on `main` in step with the released version. Safe to squash-merge.

Opened manually because the workflow's `sync-package-json` job was blocked by the org setting **"Allow GitHub Actions to create and approve pull requests"** (Settings → Actions → General). The bump branch itself was pushed by the workflow; only PR creation was blocked. Enable that setting to let future releases auto-open this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)