### PR TITLE
fix(watcher): degrade to polling on fs.watch errors instead of crashing

### DIFF
--- a/docs/wiki/_generated/files.json
+++ b/docs/wiki/_generated/files.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-28",
+  "generated_at": "2026-06-08",
   "source_roots": [
     "server/lib",
     "server/bin"
@@ -84,7 +84,7 @@
     },
     {
       "path": "server/lib/file-watcher.mjs",
-      "purpose": "Try to set up fs.watch for a brain subdirectory. Returns true on success.",
+      "purpose": "Recursive fs.watch over brain content with a polling fallback.",
       "exports": [
         "FileWatcher"
       ],

--- a/docs/wiki/map-files.md
+++ b/docs/wiki/map-files.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [MAP-FILES]
 references: []
 owner: core
-last_reviewed: 2026-04-28
+last_reviewed: 2026-06-08
 generated: true
 source_roots: [server/lib, server/bin]
 ---
@@ -23,7 +23,7 @@ Generated walk of `server/lib`, `server/bin`. Do not hand-edit — regenerate wi
 | `server/lib/bus.mjs` | wicked-bus integration for wicked-brain-server. | `busAvailable`, `dropBusDeadLetter`, `emitEvent`, `getBusDb`, `isBusAvailable`, `listBusDeadLetters`, `replayBusDeadLetter`, `waitForBus` | — |
 | `server/lib/canonical-registry.mjs` | Canonical registry: maps canonical IDs (e.g. "INV-PATHS-FORWARD") to the single page that owns them. Detects violations of the "one page per ID" rule and broken references. | `buildRegistry`, `findBrokenReferences`, `loadWikiEntries` | `./frontmatter.mjs` |
 | `server/lib/detect-mode.mjs` | Pure classifier. Takes shallow scan inputs, returns mode verdict. | `classifyRepo`, `defaultWikiRoots`, `detectRepoMode` | — |
-| `server/lib/file-watcher.mjs` | Try to set up fs.watch for a brain subdirectory. Returns true on success. | `FileWatcher` | — |
+| `server/lib/file-watcher.mjs` | Recursive fs.watch over brain content with a polling fallback. | `FileWatcher` | — |
 | `server/lib/frontmatter.mjs` | Minimal YAML-subset frontmatter parser. | `extractFrontmatter`, `getField`, `parseFrontmatter`, `parseFrontmatterBlock`, `serializeFrontmatterBlock` | — |
 | `server/lib/gen-contract-api.mjs` | Contract API generator. | `extractActions`, `renderActionsJson`, `renderContractApi` | — |
 | `server/lib/gen-contract-schema.mjs` | Contract schema generator. | `extractSchema`, `renderContractSchema`, `renderSchemaJson` | — |

--- a/server/bin/wicked-brain-call.mjs
+++ b/server/bin/wicked-brain-call.mjs
@@ -11,6 +11,9 @@ import {
   unlinkSync,
   existsSync,
   mkdirSync,
+  openSync,
+  closeSync,
+  statSync,
 } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { homedir } from "node:os";
@@ -186,6 +189,24 @@ function pidAlive(pid) {
 
 // ---------- server lifecycle ----------
 
+// Open {brain}/_meta/server.log for the detached daemon's stdout+stderr. Without
+// this the server is spawned with stdio:"ignore", so a boot crash (e.g. an
+// EMFILE watch error) vanishes and the only symptom is the "did not become
+// ready" timeout below. Caps growth: starts fresh if the existing log exceeds
+// 5 MB so a long-lived daemon stays diagnosable without growing unbounded.
+function openServerLog(brainPath) {
+  const logPath = join(brainPath, "_meta", "server.log");
+  let flag = "a";
+  try {
+    if (statSync(logPath).size > 5 * 1024 * 1024) flag = "w";
+  } catch {}
+  try {
+    return { fd: openSync(logPath, flag), logPath };
+  } catch {
+    return { fd: null, logPath };
+  }
+}
+
 async function ensureServer(brainPath, opts) {
   const { explicitPort, sourceOverride, noSpawn, log, spawnTimeoutMs = 10_000 } = opts;
   const meta = readMetaConfig(brainPath);
@@ -227,15 +248,23 @@ async function ensureServer(brainPath, opts) {
     const argv = [SERVER_BIN, "--brain", brainPath, "--port", String(port)];
     if (sourcePath) argv.push("--source", sourcePath);
 
+    const { fd: logFd, logPath } = openServerLog(brainPath);
     const child = spawn(process.execPath, argv, {
       detached: true,
-      stdio: "ignore",
+      stdio: logFd === null ? "ignore" : ["ignore", logFd, logFd],
       windowsHide: true,
     });
     child.unref();
+    if (logFd !== null) {
+      try { closeSync(logFd); } catch {}
+      log(`server logs -> ${logPath}`);
+    }
 
     if (await waitForHealth(port, spawnTimeoutMs)) return port;
-    throw new Error(`server did not become ready within ${spawnTimeoutMs}ms on port ${port}`);
+    throw new Error(
+      `server did not become ready within ${spawnTimeoutMs}ms on port ${port}` +
+        (logFd !== null ? ` — see ${logPath} for the cause` : ""),
+    );
   } finally {
     releaseLock(lockPath);
   }

--- a/server/bin/wicked-brain-call.mjs
+++ b/server/bin/wicked-brain-call.mjs
@@ -249,16 +249,21 @@ async function ensureServer(brainPath, opts) {
     if (sourcePath) argv.push("--source", sourcePath);
 
     const { fd: logFd, logPath } = openServerLog(brainPath);
-    const child = spawn(process.execPath, argv, {
-      detached: true,
-      stdio: logFd === null ? "ignore" : ["ignore", logFd, logFd],
-      windowsHide: true,
-    });
-    child.unref();
-    if (logFd !== null) {
-      try { closeSync(logFd); } catch {}
-      log(`server logs -> ${logPath}`);
+    try {
+      const child = spawn(process.execPath, argv, {
+        detached: true,
+        stdio: logFd === null ? "ignore" : ["ignore", logFd, logFd],
+        windowsHide: true,
+      });
+      child.unref();
+    } finally {
+      // Close our copy of the fd in all cases — the child keeps its own. Without
+      // the finally a synchronous spawn() throw would leak the descriptor.
+      if (logFd !== null) {
+        try { closeSync(logFd); } catch {}
+      }
     }
+    if (logFd !== null) log(`server logs -> ${logPath}`);
 
     if (await waitForHealth(port, spawnTimeoutMs)) return port;
     throw new Error(

--- a/server/lib/file-watcher.mjs
+++ b/server/lib/file-watcher.mjs
@@ -1,3 +1,12 @@
+/**
+ * Recursive fs.watch over brain content with a polling fallback.
+ *
+ * Watches chunks/, wiki/, memory/ and registered project dirs; on any watch
+ * error (EMFILE/ENOSPC, or recursive watch unsupported) it degrades to polling
+ * instead of crashing the server.
+ *
+ * @module lib/file-watcher
+ */
 import { watch, readFileSync, existsSync, readdirSync, statSync, realpathSync } from "node:fs";
 import { join, relative } from "node:path";
 import { createHash } from "node:crypto";
@@ -157,8 +166,15 @@ export class FileWatcher {
     let watcher;
     try {
       watcher = this.#watch(canonicalDir(absPath), { recursive: true }, listener);
-    } catch {
-      // recursive watch not supported (Linux) — polling fallback handles it
+    } catch (err) {
+      // Resource exhaustion (EMFILE/ENFILE/ENOSPC) can throw synchronously, not
+      // only as an async 'error' event. Don't leave already-watched dirs in a
+      // half-watched state — degrade the whole watcher to polling. Other sync
+      // failures (e.g. recursive watch unsupported on older Linux) fall through
+      // to the polling fallback in start() when no watcher attaches.
+      if (err && (err.code === "EMFILE" || err.code === "ENFILE" || err.code === "ENOSPC")) {
+        this.#degradeToPolling();
+      }
       return null;
     }
     if (watcher && typeof watcher.on === "function") {
@@ -362,6 +378,7 @@ export class FileWatcher {
   }
 
   #startPolling() {
+    if (this.#pollInterval) return; // already polling — keep a single interval
     console.log("File watcher using polling mode (recursive watch not available)");
     this.#pollInterval = setInterval(() => {
       for (const dir of ["chunks", "wiki", "memory"]) {

--- a/server/lib/file-watcher.mjs
+++ b/server/lib/file-watcher.mjs
@@ -48,12 +48,26 @@ export class FileWatcher {
   #pollInterval = null;
   #onChangeCallbacks = [];
   #projects = [];
+  #watch;
 
-  constructor(brainPath, db, brainId, projects = []) {
+  constructor(brainPath, db, brainId, projects = [], watchFn = watch) {
     this.#brainPath = brainPath;
     this.#db = db;
     this.#brainId = brainId;
     this.#projects = projects;
+    // Injectable so tests can drive the FSWatcher 'error' path deterministically
+    // without exhausting real file descriptors; defaults to node:fs watch.
+    this.#watch = watchFn;
+  }
+
+  /** Active fs watcher count (0 in polling mode). Exposed for tests/diagnostics. */
+  get watcherCount() {
+    return this.#watchers.length;
+  }
+
+  /** True once the watcher has fallen back to polling. For tests/diagnostics. */
+  get polling() {
+    return this.#pollInterval !== null;
   }
 
   onFileChange(callback) {
@@ -94,18 +108,14 @@ export class FileWatcher {
     for (const project of this.#projects) {
       if (!existsSync(project.path)) continue;
       this.#scanAndHashProject(project);
-      try {
-        const watcher = watch(canonicalDir(project.path), { recursive: true }, (eventType, filename) => {
-          if (!filename) return;
-          const parts = filename.split(/[/\\]/);
-          if (parts.some(p => IGNORE_DIRS.has(p))) return;
-          const relPath = normalizePath(`projects/${project.name}/${filename}`);
-          this.#debounce(relPath, () => this.#handleProjectChange(project, filename));
-        });
-        this.#watchers.push(watcher);
-      } catch {
-        // recursive watch not supported — polling fallback already handles this
-      }
+      const watcher = this.#safeWatch(project.path, (eventType, filename) => {
+        if (!filename) return;
+        const parts = filename.split(/[/\\]/);
+        if (parts.some(p => IGNORE_DIRS.has(p))) return;
+        const relPath = normalizePath(`projects/${project.name}/${filename}`);
+        this.#debounce(relPath, () => this.#handleProjectChange(project, filename));
+      });
+      if (watcher) this.#watchers.push(watcher);
     }
 
     // If no watchers were set up (Linux), use polling fallback
@@ -120,18 +130,60 @@ export class FileWatcher {
   #tryWatch(dir) {
     const absDir = join(this.#brainPath, dir);
     if (!existsSync(absDir)) return false;
+    const watcher = this.#safeWatch(absDir, (eventType, filename) => {
+      if (!filename || !filename.endsWith(".md")) return;
+      const relPath = normalizePath(`${dir}/${filename}`);
+      this.#debounce(relPath, () => this.#handleChange(relPath));
+    });
+    if (!watcher) return false;
+    this.#watchers.push(watcher);
+    return true;
+  }
+
+  /**
+   * Create a recursive fs.watch with an 'error' handler attached. An unhandled
+   * 'error' event on an FSWatcher is rethrown by Node and crashes the entire
+   * server — that turned a common, recoverable condition (EMFILE when the
+   * open-file limit is low on macOS, ENOSPC/inotify exhaustion on Linux) into a
+   * fatal boot crash that left the brain permanently stale. On any watch error
+   * we degrade to polling, which holds no persistent watch descriptors.
+   *
+   * Returns the watcher, or null if watching could not be started (caller then
+   * relies on the polling fallback). The path is canonicalized first — see
+   * canonicalDir; required on Windows to avoid a libuv abort on 8.3 paths.
+   */
+  #safeWatch(absPath, listener) {
+    if (this.#pollInterval) return null; // already degraded — don't reopen fs watches
+    let watcher;
     try {
-      const watcher = watch(canonicalDir(absDir), { recursive: true }, (eventType, filename) => {
-        if (!filename || !filename.endsWith(".md")) return;
-        const relPath = normalizePath(`${dir}/${filename}`);
-        this.#debounce(relPath, () => this.#handleChange(relPath));
-      });
-      this.#watchers.push(watcher);
-      return true;
+      watcher = this.#watch(canonicalDir(absPath), { recursive: true }, listener);
     } catch {
       // recursive watch not supported (Linux) — polling fallback handles it
-      return false;
+      return null;
     }
+    if (watcher && typeof watcher.on === "function") {
+      watcher.on("error", (err) => this.#onWatchError(err));
+    }
+    return watcher;
+  }
+
+  /** A watch backend errored. Log and fall back to polling rather than crash. */
+  #onWatchError(err) {
+    const code = (err && err.code) || "UNKNOWN";
+    console.error(
+      `[watcher] fs.watch error (${code}) — degrading to polling: ${(err && err.message) || err}`,
+    );
+    this.#degradeToPolling();
+  }
+
+  /** Tear down fs watchers and switch to polling. Idempotent. */
+  #degradeToPolling() {
+    if (this.#pollInterval) return; // already polling
+    for (const w of this.#watchers) {
+      try { w.close(); } catch {}
+    }
+    this.#watchers = [];
+    this.#startPolling();
   }
 
   stop() {

--- a/server/test/file-watcher.test.mjs
+++ b/server/test/file-watcher.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -87,6 +88,45 @@ test("removes a .md file from index when deleted", async () => {
     unlinkSync(filePath);
 
     await waitFor(() => db.search({ query: "deleted" }).results.length === 0);
+  } finally {
+    watcher.stop();
+    db.close();
+    rmSync(brainPath, { recursive: true, force: true });
+  }
+});
+
+test("survives an fs.watch 'error' event and degrades to polling instead of crashing", () => {
+  const { brainPath, db } = makeBrain();
+  // makeBrain creates chunks/ and wiki/; the watcher also watches memory/.
+  mkdirSync(join(brainPath, "memory"), { recursive: true });
+
+  const created = [];
+  // Inject a fake watch so the FSWatcher 'error' event can be driven
+  // deterministically — a real EMFILE depends on the OS file-descriptor limit.
+  const fakeWatch = () => {
+    const w = new EventEmitter();
+    w.close = () => {};
+    created.push(w);
+    return w;
+  };
+
+  const watcher = new FileWatcher(brainPath, db, "test-brain", [], fakeWatch);
+  watcher.start();
+
+  try {
+    assert.ok(watcher.watcherCount > 0, "fs watchers active before the error");
+    assert.equal(watcher.polling, false, "not polling before the error");
+
+    const emfile = Object.assign(
+      new Error("EMFILE: too many open files, watch"),
+      { code: "EMFILE" },
+    );
+    // Unhandled, this 'error' event is rethrown by Node and crashes the whole
+    // server. The watcher must catch it and keep the process alive.
+    assert.doesNotThrow(() => created[0].emit("error", emfile));
+
+    assert.equal(watcher.watcherCount, 0, "fs watchers torn down after error");
+    assert.equal(watcher.polling, true, "degraded to polling after error");
   } finally {
     watcher.stop();
     db.close();

--- a/server/test/file-watcher.test.mjs
+++ b/server/test/file-watcher.test.mjs
@@ -133,3 +133,36 @@ test("survives an fs.watch 'error' event and degrades to polling instead of cras
     rmSync(brainPath, { recursive: true, force: true });
   }
 });
+
+test("degrades to polling when fs.watch throws EMFILE synchronously during init", () => {
+  const { brainPath, db } = makeBrain();
+  mkdirSync(join(brainPath, "memory"), { recursive: true });
+
+  let calls = 0;
+  // First dir attaches; the second throws EMFILE synchronously. Without the
+  // resource-aware catch the first dir stays watched while the rest are left
+  // neither watched nor polled — a silent half-watched state.
+  const throwingWatch = () => {
+    calls++;
+    if (calls === 1) {
+      const w = new EventEmitter();
+      w.close = () => {};
+      return w;
+    }
+    const err = new Error("EMFILE: too many open files, watch");
+    err.code = "EMFILE";
+    throw err;
+  };
+
+  const watcher = new FileWatcher(brainPath, db, "test-brain", [], throwingWatch);
+  assert.doesNotThrow(() => watcher.start());
+
+  try {
+    assert.equal(watcher.watcherCount, 0, "partial fs watchers torn down");
+    assert.equal(watcher.polling, true, "degraded to polling on sync EMFILE");
+  } finally {
+    watcher.stop();
+    db.close();
+    rmSync(brainPath, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem
The brain server crash-looped on boot. It bound the port, then `watcher.start()`
created `fs.watch` FSWatchers with **no `error` handler**. Under file-descriptor
pressure the recursive watch fires **EMFILE** (macOS — a detached daemon inherits
the launchd `maxfiles` soft limit of 256) or **ENOSPC** (Linux inotify); an
unhandled `'error'` event is rethrown by Node → `exit(1)` ~1s after boot.

Because `wicked-brain-call` spawned the daemon with `stdio: "ignore"`, the crash
was invisible — the only symptom was the generic *"server did not become ready"*
timeout. Net effect: the brain was permanently unreachable, so every agent got
stale/empty context.

## Fix
- **file-watcher**: `#safeWatch` attaches an `error` handler to every FSWatcher;
  on any watch error it tears down the fs watchers and degrades to **polling**
  (which holds no persistent watch descriptors) instead of crashing. The `watch`
  fn is injectable for tests; `watcherCount`/`polling` getters aid diagnostics.
- **wicked-brain-call**: route the detached daemon's stdout+stderr to
  `{brain}/_meta/server.log` (size-capped at 5 MB) instead of `stdio:"ignore"`,
  and point the "did not become ready" error at the log.
- **test**: regression test proving an EMFILE `'error'` degrades to polling
  rather than crashing the process.

## Evidence
- `node --test`: **345/345 pass**.
- The live daemon log now shows the real failure-and-recovery, previously sent
  to `/dev/null`:
  `[watcher] fs.watch error (EMFILE) — degrading to polling` → server stays up
  (it was crashing ~1s into boot, every time).

## Follow-ups (not in this PR)
- **Durable bus-cursor self-heal:** after a long outage the auto-memorize
  subscriber's wicked-bus cursor falls behind the TTL window and `poll()` throws
  `WB-003` every 5s (auto-memorize stalls). Repaired operationally this session;
  recommend a startup guard that resets a behind-TTL cursor to `latest`.
- Optional: raise macOS `launchctl limit maxfiles` to avoid the polling fallback.

## Release
Tag-driven per `CLAUDE.md`: after merge, `git tag vX.Y.Z && git push --tags`
publishes. This is a release-worthy crash fix for downstream brains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
