### PR TITLE
feat(codegraph): Phase 1a — code-relationship graph core (blast-radius/lineage/callers)

### DIFF
--- a/docs/codegraph-contract.md
+++ b/docs/codegraph-contract.md
@@ -1,0 +1,295 @@
+# codegraph contract
+
+Empirical characterization of `@colbymchenry/codegraph` schema and behaviour.
+Produced by a spike run on 2026-06-10. Downstream tasks MUST cite this document
+for schema column names and the `DEPENDENTS_BY` constant — do not assume.
+
+---
+
+## Version
+
+```
+$ npx -y @colbymchenry/codegraph --version
+0.9.9
+```
+
+---
+
+## Index command contract
+
+The CLI requires **`init`** for a first-time run (creates `.codegraph/` and
+builds the full index in one step). Subsequent re-indexes use `index`.
+
+```
+# First time on a repo (creates .codegraph/codegraph.db + indexes)
+npx -y @colbymchenry/codegraph init [path]
+
+# Re-index after changes
+npx -y @colbymchenry/codegraph index [path]
+npx -y @colbymchenry/codegraph index --force [path]   # force full re-index
+npx -y @colbymchenry/codegraph index --quiet  [path]  # suppress progress
+```
+
+`[path]` is optional — defaults to cwd. Both commands accept an explicit
+directory as a positional argument.
+
+**`index` on a repo that has not been `init`-ed will fail** because
+`.codegraph/codegraph.db` does not yet exist. The correct bootstrap sequence
+is always `init` first, then `index` for subsequent updates. (Attempting to
+call `index` on a fresh directory raises an error; `init` is the entry point.)
+
+### `init` output (actual, from spike)
+
+```
+┌  Initializing CodeGraph
+│
+◆  Initialized in /private/tmp/cg-spike
+│
+│  · Scanning files...
+│  ◆ Scanning files — 2 found
+│  · Parsing code  ░░░░░░░░░░░░░░░░░░░░░░░░░  0%
+│  ◆ Parsing code — done
+│  ◆ Resolving refs — done
+│
+◆  Indexed 2 files
+│
+●  5 nodes, 5 edges in 184ms
+│
+└  Done
+```
+
+---
+
+## `nodes` table
+
+### Full schema (from `.schema nodes`)
+
+```sql
+CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    qualified_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    start_column INTEGER NOT NULL,
+    end_column INTEGER NOT NULL,
+    docstring TEXT,
+    signature TEXT,
+    visibility TEXT,
+    is_exported INTEGER DEFAULT 0,
+    is_async INTEGER DEFAULT 0,
+    is_static INTEGER DEFAULT 0,
+    is_abstract INTEGER DEFAULT 0,
+    decorators TEXT,           -- JSON array
+    type_parameters TEXT,      -- JSON array
+    updated_at INTEGER NOT NULL
+);
+```
+
+### Column list (ordered)
+
+`id`, `kind`, `name`, `qualified_name`, `file_path`, `language`,
+`start_line`, `end_line`, `start_column`, `end_column`,
+`docstring`, `signature`, `visibility`,
+`is_exported`, `is_async`, `is_static`, `is_abstract`,
+`decorators`, `type_parameters`, `updated_at`
+
+### Node id format
+
+Node ids use `<kind>:<hash_or_relpath>` format:
+- **file nodes**: `file:<relpath>` — e.g., `file:a.py`, `file:b.py`
+- **function nodes**: `function:<md5-ish-hash>` — e.g., `function:cf8a577152c7b744850fea3476634811`
+- **import nodes**: `import:<hash>` — e.g., `import:87573e212582ddea370092f138bb269e`
+
+### Actual node rows from spike (2-file fixture: a.py + b.py)
+
+```
+id                                            | kind     | name    | qualified_name | file_path
+----------------------------------------------|----------|---------|---------------|----------
+file:a.py                                     | file     | a.py    | a.py           | a.py
+function:cf8a577152c7b744850fea3476634811      | function | base    | base           | a.py
+file:b.py                                     | file     | b.py    | b.py           | b.py
+import:87573e212582ddea370092f138bb269e        | import   | a       | a              | b.py
+function:4d743eac618702bb486052d27f77ddc6      | function | caller  | caller         | b.py
+```
+
+Fixture source:
+- `a.py`: `def base(): pass`
+- `b.py`: `from a import base` / `def caller(): return base()`
+
+---
+
+## `edges` table
+
+### Full schema (from `.schema edges`)
+
+```sql
+CREATE TABLE edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    metadata TEXT,   -- JSON object
+    line INTEGER,
+    col INTEGER,
+    provenance TEXT DEFAULT NULL,
+    FOREIGN KEY (source) REFERENCES nodes(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES nodes(id) ON DELETE CASCADE
+);
+```
+
+### Column list (ordered)
+
+`id`, `source`, `target`, `kind`, `metadata`, `line`, `col`, `provenance`
+
+### Observed edge kinds
+
+| kind       | meaning                                    |
+|------------|--------------------------------------------|
+| `contains` | parent node contains child node            |
+| `imports`  | file imports an import-node                |
+| `calls`    | function/method calls another symbol       |
+
+### Actual edge rows from spike
+
+```
+id | source                                        | target                                        | kind     | metadata
+---|-----------------------------------------------|-----------------------------------------------|----------|--------------------------------------------------
+1  | file:a.py                                     | function:cf8a577...                           | contains |
+2  | file:b.py                                     | import:87573e21...                            | contains |
+3  | file:b.py                                     | function:4d743e...                            | contains |
+4  | file:b.py                                     | import:87573e21...                            | imports  | {"confidence":0.9,"resolvedBy":"exact-match"}
+5  | function:4d743eac618702bb486052d27f77ddc6      | function:cf8a577152c7b744850fea3476634811      | calls    | {"confidence":0.9,"resolvedBy":"exact-match"}
+```
+
+Full output of `SELECT source,target,kind,metadata FROM edges;`:
+
+```
+file:a.py|function:cf8a577152c7b744850fea3476634811|contains|
+file:b.py|import:87573e212582ddea370092f138bb269e|contains|
+file:b.py|function:4d743eac618702bb486052d27f77ddc6|contains|
+file:b.py|import:87573e212582ddea370092f138bb269e|imports|{"confidence":0.9,"resolvedBy":"exact-match"}
+function:4d743eac618702bb486052d27f77ddc6|function:cf8a577152c7b744850fea3476634811|calls|{"confidence":0.9,"resolvedBy":"exact-match"}
+```
+
+---
+
+## DEPENDENTS_BY — resolved blast-radius edge direction
+
+```
+DEPENDENTS_BY = "target"
+```
+
+### Evidence
+
+The fixture establishes a clear caller→callee relationship:
+- `b.py::caller` calls `a.py::base`
+- `caller` is the **dependent** (it breaks if `base` changes)
+- `base` is the **dependency** (the thing being changed)
+
+The observed `calls` edge row is:
+
+```
+source = function:4d743eac618702bb486052d27f77ddc6   ← caller  (b.py, the dependent)
+target = function:cf8a577152c7b744850fea3476634811   ← base    (a.py, the dependency)
+kind   = calls
+```
+
+**Edge direction: `source=consumer/dependent → target=producer/dependency`**
+
+To answer "what depends on X?" (blast radius of X — what breaks if X changes):
+
+```sql
+SELECT source FROM edges WHERE target = :x_id AND kind IN ('calls', 'imports', 'references');
+```
+
+This matches rows WHERE `target = X`, collecting `source` — hence `DEPENDENTS_BY = "target"`.
+
+### Resolution of the inject_edges.py ambiguity
+
+The wicked-garden reference implementation (`scripts/codegraph/inject_edges.py`)
+had a contradictory comment: it said blast-radius "walks incoming edges" but
+inserted producer→consumer edges. This spike resolves the ambiguity: edges are
+stored **consumer→producer** (`source=dependent, target=dependency`), so
+dependents-of-X are found by `WHERE target=X` (i.e., "incoming to X"). The
+comment in inject_edges.py was **correct** ("walks incoming edges"); the
+characterization of the insert direction was confusing but ultimately consistent
+with the observed data.
+
+---
+
+## Import edge nuance
+
+The `imports` edge does **not** point directly from `file:b.py` to `file:a.py`.
+Instead, codegraph creates an intermediate `import` kind node:
+
+```
+file:b.py  --[imports]--> import:<hash>  (name="a", file_path="b.py")
+```
+
+The import node has `name = "a"` (the module name, not the file path). The
+`import` node itself does NOT have a resolved edge to `file:a.py` in this
+fixture — the `imports` edge goes file→import-node, not file→file. For
+file-level blast-radius traversal, resolving `import` nodes to their target
+`file` nodes requires matching the import node's `name` against file node
+`name` values (or `file_path`).
+
+The `calls` edge, by contrast, is fully resolved: it points directly from
+`function:<hash>` to `function:<hash>`, crossing the file boundary.
+
+---
+
+## Schema versions (from `schema_versions` table)
+
+```
+version | description
+--------|------------------------------------------
+1       | Initial schema
+4       | Initial schema includes all migrations
+```
+
+DB is at version 4 with codegraph 0.9.9.
+
+---
+
+## Additional tables
+
+Beyond `nodes` and `edges`, the DB contains:
+
+| table              | purpose                                        |
+|--------------------|------------------------------------------------|
+| `files`            | per-file index metadata (hash, language, size) |
+| `unresolved_refs`  | references codegraph could not resolve         |
+| `project_metadata` | key/value store for project-level metadata     |
+| `schema_versions`  | migration history                              |
+| `nodes_fts`        | FTS5 virtual table over nodes (name, docstring)|
+
+---
+
+## Surprises
+
+1. **`init` is required first, not `index`.** The task description suggested
+   `npx -y @colbymchenry/codegraph index .` but that requires a pre-existing
+   `.codegraph/` directory. For a fresh repo, `init` is the correct entry point.
+   `init` both initializes and indexes in one step. `index --help` confirms it
+   only re-indexes; `init --help` confirms it is the bootstrap command.
+
+2. **Import edges use intermediate import nodes**, not direct file→file edges.
+   The `imports` edge goes `file:b.py → import:<hash>` where the import node
+   has `name="a"` (the Python module name). Resolution to `file:a.py` requires
+   a second lookup step.
+
+3. **Node ids use content-hash suffixes** for non-file nodes. The `id` for a
+   function is `function:<md5-style-hash>` — not `file:relpath::symbol_name`.
+   `qualified_name` (e.g., `"base"`, `"caller"`) is the human-readable key for
+   symbol lookups.
+
+4. **`metadata` column is JSON**, not split into separate columns.
+   Resolved edges carry `{"confidence": 0.9, "resolvedBy": "exact-match"}`.
+
+5. **`col` in edges is 0-indexed byte offset**, not 1-indexed column.
+   The `calls` edge shows `col=21` which is the byte offset of `base()` in
+   `def caller(): return base()`.

--- a/docs/wiki/_generated/actions.json
+++ b/docs/wiki/_generated/actions.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-28",
+  "generated_at": "2026-06-10",
   "source": "server/bin/wicked-brain-server.mjs",
   "canonical_id": "CONTRACT-API",
   "count": 40,

--- a/docs/wiki/_generated/files.json
+++ b/docs/wiki/_generated/files.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-06-08",
+  "generated_at": "2026-06-10",
   "source_roots": [
     "server/lib",
     "server/bin"
   ],
   "canonical_id": "MAP-FILES",
-  "count": 26,
+  "count": 32,
   "files": [
     {
       "path": "server/bin/onboard-wiki.mjs",
@@ -28,6 +28,7 @@
       "imports": [
         "../lib/brain-walker.mjs",
         "../lib/bus.mjs",
+        "../lib/codegraph-actions.mjs",
         "../lib/file-watcher.mjs",
         "../lib/lsp-client.mjs",
         "../lib/memory-subscriber.mjs",
@@ -71,6 +72,72 @@
       "imports": [
         "./frontmatter.mjs"
       ]
+    },
+    {
+      "path": "server/lib/codegraph-actions.mjs",
+      "purpose": "Build the graph-* action handlers bound to a source repo. A fresh client per call keeps the readonly DB handle short-lived and always reopens after a rebuild.",
+      "exports": [
+        "makeGraphActions"
+      ],
+      "imports": [
+        "./codegraph-client.mjs",
+        "./codegraph-extract.mjs",
+        "./codegraph-index.mjs"
+      ]
+    },
+    {
+      "path": "server/lib/codegraph-client.mjs",
+      "purpose": "Transitive dependents — \"what breaks if I change X\".",
+      "exports": [
+        "CodegraphClient"
+      ],
+      "imports": [
+        "./codegraph-index.mjs"
+      ]
+    },
+    {
+      "path": "server/lib/codegraph-extract.mjs",
+      "purpose": "codegraph-extract.mjs — extractor registry (builtins + drop-ins).",
+      "exports": [
+        "discoverDropins",
+        "runExtractors"
+      ],
+      "imports": [
+        "./codegraph-extractors/bus.mjs",
+        "./codegraph-extractors/capability.mjs",
+        "./codegraph-extractors/dispatch.mjs",
+        "./codegraph-nodes.mjs"
+      ]
+    },
+    {
+      "path": "server/lib/codegraph-index.mjs",
+      "purpose": "How far the graph has drifted from HEAD. Fail-open: errors report present-but-unknown, never throw. @returns {{present:boolean, stale:boolean|null, commits_behind:number|null, indexed_at:string|null}}",
+      "exports": [
+        "dbPath",
+        "runIndex",
+        "staleness"
+      ],
+      "imports": [
+        "./codegraph-resolver.mjs"
+      ]
+    },
+    {
+      "path": "server/lib/codegraph-nodes.mjs",
+      "purpose": "codegraph-nodes.mjs — self-noding helpers for injected-edge extractors.",
+      "exports": [
+        "ensureFileNode",
+        "ensureVirtualNode"
+      ],
+      "imports": []
+    },
+    {
+      "path": "server/lib/codegraph-resolver.mjs",
+      "purpose": "Resolve the argv prefix that invokes codegraph, or null. Ladder: WICKED_CODEGRAPH_BIN (set-but-empty = kill switch) -> brain _meta/codegraph.json {bin} -> PATH -> source node_modules/.bin -> `npx`.",
+      "exports": [
+        "codegraphAvailable",
+        "resolveCodegraph"
+      ],
+      "imports": []
     },
     {
       "path": "server/lib/detect-mode.mjs",

--- a/docs/wiki/_generated/schema.json
+++ b/docs/wiki/_generated/schema.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-28",
+  "generated_at": "2026-06-10",
   "source": "server/lib/sqlite-search.mjs",
   "canonical_id": "CONTRACT-SCHEMA",
   "head_version": 6,

--- a/docs/wiki/contract-api.md
+++ b/docs/wiki/contract-api.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [CONTRACT-API]
 references: []
 owner: core
-last_reviewed: 2026-04-28
+last_reviewed: 2026-06-10
 generated: true
 source: server/bin/wicked-brain-server.mjs
 ---

--- a/docs/wiki/contract-schema.md
+++ b/docs/wiki/contract-schema.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [CONTRACT-SCHEMA]
 references: [INV-MIGRATION-REQUIRED]
 owner: core
-last_reviewed: 2026-04-28
+last_reviewed: 2026-06-10
 generated: true
 source: server/lib/sqlite-search.mjs
 ---

--- a/docs/wiki/map-files.md
+++ b/docs/wiki/map-files.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [MAP-FILES]
 references: []
 owner: core
-last_reviewed: 2026-06-08
+last_reviewed: 2026-06-10
 generated: true
 source_roots: [server/lib, server/bin]
 ---
@@ -18,10 +18,16 @@ Generated walk of `server/lib`, `server/bin`. Do not hand-edit — regenerate wi
 |---|---|---|---|
 | `server/bin/onboard-wiki.mjs` | wicked-brain-onboard-wiki | — | `../lib/onboard-wiki.mjs` |
 | `server/bin/wicked-brain-call.mjs` | — | — | — |
-| `server/bin/wicked-brain-server.mjs` | Listen on `startPort`, probing upward on EADDRINUSE. Probes using the real server instance so the bind semantics (dual-stack IPv4+IPv6) match the eventual listener — a separate 127.0.0.1 probe would miss an IPv6-only conflict and produce a false "free" result. | — | `../lib/brain-walker.mjs`, `../lib/bus.mjs`, `../lib/file-watcher.mjs`, `../lib/lsp-client.mjs`, `../lib/memory-subscriber.mjs`, `../lib/onboard-wiki.mjs`, `../lib/sqlite-search.mjs`, `../lib/viewer-page.mjs` |
+| `server/bin/wicked-brain-server.mjs` | Listen on `startPort`, probing upward on EADDRINUSE. Probes using the real server instance so the bind semantics (dual-stack IPv4+IPv6) match the eventual listener — a separate 127.0.0.1 probe would miss an IPv6-only conflict and produce a false "free" result. | — | `../lib/brain-walker.mjs`, `../lib/bus.mjs`, `../lib/codegraph-actions.mjs`, `../lib/file-watcher.mjs`, `../lib/lsp-client.mjs`, `../lib/memory-subscriber.mjs`, `../lib/onboard-wiki.mjs`, `../lib/sqlite-search.mjs`, `../lib/viewer-page.mjs` |
 | `server/lib/brain-walker.mjs` | Walk a brain path and surface every authored `.md` file under the content subdirectories (chunks/, wiki/, memory/). Deliberately excludes `_meta/`, `raw/`, `.brain.db`, and any dotfile/dotdir. Paths returned are relative to the brain path and use forward slashes per INV-PATHS-FORWARD. | `purgeBrainContent`, `walkBrainContent` | — |
 | `server/lib/bus.mjs` | wicked-bus integration for wicked-brain-server. | `busAvailable`, `dropBusDeadLetter`, `emitEvent`, `getBusDb`, `isBusAvailable`, `listBusDeadLetters`, `replayBusDeadLetter`, `waitForBus` | — |
 | `server/lib/canonical-registry.mjs` | Canonical registry: maps canonical IDs (e.g. "INV-PATHS-FORWARD") to the single page that owns them. Detects violations of the "one page per ID" rule and broken references. | `buildRegistry`, `findBrokenReferences`, `loadWikiEntries` | `./frontmatter.mjs` |
+| `server/lib/codegraph-actions.mjs` | Build the graph-* action handlers bound to a source repo. A fresh client per call keeps the readonly DB handle short-lived and always reopens after a rebuild. | `makeGraphActions` | `./codegraph-client.mjs`, `./codegraph-extract.mjs`, `./codegraph-index.mjs` |
+| `server/lib/codegraph-client.mjs` | Transitive dependents — "what breaks if I change X". | `CodegraphClient` | `./codegraph-index.mjs` |
+| `server/lib/codegraph-extract.mjs` | codegraph-extract.mjs — extractor registry (builtins + drop-ins). | `discoverDropins`, `runExtractors` | `./codegraph-extractors/bus.mjs`, `./codegraph-extractors/capability.mjs`, `./codegraph-extractors/dispatch.mjs`, `./codegraph-nodes.mjs` |
+| `server/lib/codegraph-index.mjs` | How far the graph has drifted from HEAD. Fail-open: errors report present-but-unknown, never throw. @returns {{present:boolean, stale:boolean\|null, commits_behind:number\|null, indexed_at:string\|null}} | `dbPath`, `runIndex`, `staleness` | `./codegraph-resolver.mjs` |
+| `server/lib/codegraph-nodes.mjs` | codegraph-nodes.mjs — self-noding helpers for injected-edge extractors. | `ensureFileNode`, `ensureVirtualNode` | — |
+| `server/lib/codegraph-resolver.mjs` | Resolve the argv prefix that invokes codegraph, or null. Ladder: WICKED_CODEGRAPH_BIN (set-but-empty = kill switch) -> brain _meta/codegraph.json {bin} -> PATH -> source node_modules/.bin -> `npx`. | `codegraphAvailable`, `resolveCodegraph` | — |
 | `server/lib/detect-mode.mjs` | Pure classifier. Takes shallow scan inputs, returns mode verdict. | `classifyRepo`, `defaultWikiRoots`, `detectRepoMode` | — |
 | `server/lib/file-watcher.mjs` | Recursive fs.watch over brain content with a polling fallback. | `FileWatcher` | — |
 | `server/lib/frontmatter.mjs` | Minimal YAML-subset frontmatter parser. | `extractFrontmatter`, `getField`, `parseFrontmatter`, `parseFrontmatterBlock`, `serializeFrontmatterBlock` | — |

--- a/server/bin/wicked-brain-server.mjs
+++ b/server/bin/wicked-brain-server.mjs
@@ -18,6 +18,7 @@ import { renderViewerHtml } from "../lib/viewer-page.mjs";
 import { walkBrainContent, purgeBrainContent } from "../lib/brain-walker.mjs";
 import { runOnboardWiki } from "../lib/onboard-wiki.mjs";
 import { readFile as readFileAsync } from "node:fs/promises";
+import { makeGraphActions } from "../lib/codegraph-actions.mjs";
 
 // Parse args
 const args = argv.slice(2);
@@ -112,6 +113,7 @@ try {
 
 // LSP client — pass source path so language servers are rooted at the project, not the brain dir
 const lsp = new LspClient(brainPath, db, sourcePath);
+const graphActions = makeGraphActions({ sourcePath, brainPath });
 
 // Auto-memorize subscriber handle (set after bus init in server.listen callback)
 let memorySubscriber = null;
@@ -246,6 +248,8 @@ const actions = {
   "lsp-call-hierarchy-in": (p) => lsp.callHierarchyIn(p),
   "lsp-call-hierarchy-out": (p) => lsp.callHierarchyOut(p),
   "lsp-diagnostics": (p) => lsp.diagnostics(p),
+  // Graph (codegraph) actions
+  ...graphActions,
   reonboard: async () => {
     // Detect mode + stamp the CLAUDE.md/AGENTS.md pointer, then rebuild the
     // search index from whatever content is on disk in this brain. Does NOT
@@ -318,6 +322,8 @@ const WRITE_ACTIONS = new Set([
   // DLQ replay/drop mutate the bus DB; list is read-only.
   "dlq_replay",
   "dlq_drop",
+  // Graph rebuild is a write — shells out to codegraph CLI.
+  "graph-index",
 ]);
 
 // HTTP server

--- a/server/lib/codegraph-actions.mjs
+++ b/server/lib/codegraph-actions.mjs
@@ -1,5 +1,7 @@
+import Database from "better-sqlite3";
 import { CodegraphClient } from "./codegraph-client.mjs";
-import { runIndex, staleness } from "./codegraph-index.mjs";
+import { runIndex, staleness, dbPath } from "./codegraph-index.mjs";
+import { runExtractors } from "./codegraph-extract.mjs";
 
 /**
  * Build the graph-* action handlers bound to a source repo. A fresh client per
@@ -16,7 +18,17 @@ export function makeGraphActions({ sourcePath, brainPath } = {}) {
     "graph-lineage": (p = {}) => withClient((c) => c.lineage({ node: p.node, maxDepth: p.maxDepth })),
     "graph-index": async () => {
       const r = await runIndex(sourcePath, { brainPath, sourcePath });
-      return { ...r, staleness: staleness(sourcePath) };
+      if (!r.ok) {
+        return { ...r, staleness: staleness(sourcePath) };
+      }
+      const db = new Database(dbPath(sourcePath));
+      let injected;
+      try {
+        injected = await runExtractors({ db, sourcePath });
+      } finally {
+        db.close();
+      }
+      return { ...r, injected, staleness: staleness(sourcePath) };
     },
   };
 }

--- a/server/lib/codegraph-actions.mjs
+++ b/server/lib/codegraph-actions.mjs
@@ -1,0 +1,22 @@
+import { CodegraphClient } from "./codegraph-client.mjs";
+import { runIndex, staleness } from "./codegraph-index.mjs";
+
+/**
+ * Build the graph-* action handlers bound to a source repo. A fresh client per
+ * call keeps the readonly DB handle short-lived and always reopens after a rebuild.
+ */
+export function makeGraphActions({ sourcePath, brainPath } = {}) {
+  const withClient = (fn) => {
+    const c = new CodegraphClient(sourcePath);
+    try { return fn(c); } finally { c.close(); }
+  };
+  return {
+    "graph-blast-radius": (p = {}) => withClient((c) => c.blastRadius({ node: p.node, maxDepth: p.maxDepth })),
+    "graph-callers": (p = {}) => withClient((c) => c.callers({ node: p.node })),
+    "graph-lineage": (p = {}) => withClient((c) => c.lineage({ node: p.node, maxDepth: p.maxDepth })),
+    "graph-index": async () => {
+      const r = await runIndex(sourcePath, { brainPath, sourcePath });
+      return { ...r, staleness: staleness(sourcePath) };
+    },
+  };
+}

--- a/server/lib/codegraph-client.mjs
+++ b/server/lib/codegraph-client.mjs
@@ -1,0 +1,85 @@
+import { existsSync } from "node:fs";
+import Database from "better-sqlite3";
+import { dbPath, staleness } from "./codegraph-index.mjs";
+
+// Pinned by Task 1 (docs/codegraph-contract.md): edges are stored
+// consumer->producer, edge(source=dependent, target=dependency). So dependents
+// of X are rows WHERE target=X (collect source); dependencies are the inverse.
+const DEPENDENTS_BY = "target";
+const DEPENDENCIES_BY = DEPENDENTS_BY === "target" ? "source" : "target";
+
+export class CodegraphClient {
+  #sourcePath;
+  #db = null;
+
+  constructor(sourcePath) { this.#sourcePath = sourcePath; }
+
+  #open() {
+    if (this.#db) return this.#db;
+    const p = dbPath(this.#sourcePath);
+    if (!existsSync(p)) return null;
+    this.#db = new Database(p, { readonly: true });
+    return this.#db;
+  }
+
+  close() { if (this.#db) { this.#db.close(); this.#db = null; } }
+
+  #nodeRows(ids) {
+    if (ids.length === 0) return [];
+    const ph = ids.map(() => "?").join(",");
+    return this.#db.prepare(
+      `SELECT id, kind, name, file_path, start_line, end_line FROM nodes WHERE id IN (${ph})`
+    ).all(...ids);
+  }
+
+  // BFS over edges. matchCol = the column matched against the frontier;
+  // collectCol = the column collected as the next frontier.
+  #walk(start, { matchCol, collectCol, maxDepth }) {
+    const stmt = this.#db.prepare(
+      `SELECT DISTINCT ${collectCol} AS next FROM edges WHERE ${matchCol} = ?`);
+    const seen = new Set();
+    let frontier = [start];
+    let depth = 0;
+    while (frontier.length && depth < maxDepth) {
+      const nextFrontier = [];
+      for (const node of frontier) {
+        for (const row of stmt.all(node)) {
+          if (row.next && row.next !== start && !seen.has(row.next)) {
+            seen.add(row.next);
+            nextFrontier.push(row.next);
+          }
+        }
+      }
+      frontier = nextFrontier;
+      depth += 1;
+    }
+    return [...seen];
+  }
+
+  #unavailable() {
+    return { engine: "unavailable",
+      reason: `no graph at ${dbPath(this.#sourcePath)} — run graph-index`,
+      staleness: staleness(this.#sourcePath) };
+  }
+
+  /** Transitive dependents — "what breaks if I change X". */
+  blastRadius({ node, maxDepth = 25 }) {
+    if (!this.#open()) return this.#unavailable();
+    const ids = this.#walk(node, { matchCol: DEPENDENTS_BY, collectCol: DEPENDENCIES_BY, maxDepth });
+    return { node, dependents: this.#nodeRows(ids), staleness: staleness(this.#sourcePath) };
+  }
+
+  /** Direct dependents only (depth 1). */
+  callers({ node }) {
+    if (!this.#open()) return this.#unavailable();
+    const ids = this.#walk(node, { matchCol: DEPENDENTS_BY, collectCol: DEPENDENCIES_BY, maxDepth: 1 });
+    return { node, callers: this.#nodeRows(ids), staleness: staleness(this.#sourcePath) };
+  }
+
+  /** Transitive dependencies — downstream lineage. */
+  lineage({ node, maxDepth = 25 }) {
+    if (!this.#open()) return this.#unavailable();
+    const ids = this.#walk(node, { matchCol: DEPENDENCIES_BY, collectCol: DEPENDENTS_BY, maxDepth });
+    return { node, dependencies: this.#nodeRows(ids), staleness: staleness(this.#sourcePath) };
+  }
+}

--- a/server/lib/codegraph-extract.mjs
+++ b/server/lib/codegraph-extract.mjs
@@ -1,0 +1,89 @@
+/**
+ * codegraph-extract.mjs — extractor registry (builtins + drop-ins).
+ *
+ * Ships three built-in extractors and discovers per-repo drop-in extractors
+ * under <sourcePath>/.codegraph-extractors/*.mjs, each exporting `extract`.
+ *
+ * Fail-open per extractor: one throwing must not abort the rest.
+ *
+ * NOTE on drop-in imports: this imports and runs code from the target repo —
+ * by design (the repo provides trusted extractors), same trust level as
+ * running its tests.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { extract as busExtract } from "./codegraph-extractors/bus.mjs";
+import { extract as dispatchExtract } from "./codegraph-extractors/dispatch.mjs";
+import { extract as capabilityExtract } from "./codegraph-extractors/capability.mjs";
+
+const BUILTINS = [
+  { label: "bus", extract: busExtract },
+  { label: "dispatch", extract: dispatchExtract },
+  { label: "capability", extract: capabilityExtract },
+];
+
+/**
+ * Discover drop-in extractors under <sourcePath>/.codegraph-extractors/*.mjs.
+ * Each file must export a function `extract`. Sorted for deterministic ordering.
+ * Broken files (import error or missing export) are silently skipped.
+ *
+ * @param {string} sourcePath
+ * @returns {Promise<Array<{label:string, extract:Function}>>}
+ */
+export async function discoverDropins(sourcePath) {
+  const dir = join(sourcePath, ".codegraph-extractors");
+  if (!existsSync(dir)) return [];
+
+  let entries;
+  try {
+    entries = readdirSync(dir)
+      .filter((f) => f.endsWith(".mjs"))
+      .sort();
+  } catch {
+    return [];
+  }
+
+  const dropins = [];
+  for (const filename of entries) {
+    const fullpath = join(dir, filename);
+    try {
+      const mod = await import(pathToFileURL(fullpath).href);
+      if (typeof mod.extract === "function") {
+        dropins.push({ label: `dropin:${filename}`, extract: mod.extract });
+      }
+    } catch {
+      // Broken drop-in — skip, not fatal
+    }
+  }
+  return dropins;
+}
+
+/**
+ * Run all extractors (builtins + drop-ins) against the open read-write db.
+ * Fail-open per extractor: one throwing must not abort the rest.
+ *
+ * @param {{ db: import("better-sqlite3").Database, sourcePath: string }} opts
+ * @returns {Promise<Record<string, object> & { total_injected_edges: number, dropins: string[] }>}
+ */
+export async function runExtractors({ db, sourcePath }) {
+  const dropins = await discoverDropins(sourcePath);
+  const dropin_labels = dropins.map((d) => d.label);
+  const all = [...BUILTINS, ...dropins];
+
+  const out = {};
+  let total = 0;
+
+  for (const ext of all) {
+    try {
+      const counts = await ext.extract({ db, sourcePath });
+      out[ext.label] = counts;
+      total += counts.edges_added || 0;
+    } catch (e) {
+      out[ext.label] = { error: String((e && e.message) || e) };
+    }
+  }
+
+  return { ...out, total_injected_edges: total, dropins: dropin_labels };
+}

--- a/server/lib/codegraph-extract.mjs
+++ b/server/lib/codegraph-extract.mjs
@@ -17,6 +17,7 @@ import { pathToFileURL } from "node:url";
 import { extract as busExtract } from "./codegraph-extractors/bus.mjs";
 import { extract as dispatchExtract } from "./codegraph-extractors/dispatch.mjs";
 import { extract as capabilityExtract } from "./codegraph-extractors/capability.mjs";
+import { ensureFileNode, ensureVirtualNode } from "./codegraph-nodes.mjs";
 
 const BUILTINS = [
   { label: "bus", extract: busExtract },
@@ -72,12 +73,14 @@ export async function runExtractors({ db, sourcePath }) {
   const dropin_labels = dropins.map((d) => d.label);
   const all = [...BUILTINS, ...dropins];
 
+  const nodes = { ensureFileNode, ensureVirtualNode };
+
   const out = {};
   let total = 0;
 
   for (const ext of all) {
     try {
-      const counts = await ext.extract({ db, sourcePath });
+      const counts = await ext.extract({ db, sourcePath, nodes });
       out[ext.label] = counts;
       total += counts.edges_added || 0;
     } catch (e) {

--- a/server/lib/codegraph-extractors/bus.mjs
+++ b/server/lib/codegraph-extractors/bus.mjs
@@ -1,0 +1,180 @@
+/**
+ * codegraph-extractors/bus.mjs — wicked-bus producer→consumer injected edges.
+ *
+ * Port of scripts/codegraph/inject_edges.py with the edge direction CORRECTED:
+ *
+ *   Garden's inject_edges.py inserts (source=producer, target=consumer).
+ *   The contract doc resolves the ambiguity: edges are stored
+ *   source=dependent→target=dependency, and DEPENDENTS_BY="target". So
+ *   blast-radius(X) = WHERE target=X (collect source). For the consumer to
+ *   surface as a dependent of the producer, the edge must be:
+ *
+ *       source = consumer (dependent — breaks when producer's event changes)
+ *       target = producer (dependency — the thing being changed)
+ *
+ * This is the corrected direction. Garden's version inserts the opposite and
+ * is a latent bug (blast-radius of the producer would NOT surface the consumer).
+ *
+ * Algorithm:
+ *   1. DELETE edges WHERE provenance='injected:bus'   (idempotent)
+ *   2. Read <sourcePath>/scripts/_bus_consumers.json
+ *   3. Grep <sourcePath>/scripts/**\/*.py for event-string literals
+ *   4. For each consumer: confirm node exists; for each producer: confirm node
+ *      exists; INSERT edge (source=consumer, target=producer)
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const EVENT_RE = /["']((?:wicked|wg)\.[a-z0-9_]+(?:\.[a-z0-9_]+)+)["']/g;
+const INJECTED_PROVENANCE = "injected:bus";
+
+/**
+ * Read and parse _bus_consumers.json. Returns [] on missing or malformed file.
+ * @param {string} sourcePath
+ * @returns {{ event_filter: string, module: string }[]}
+ */
+function readConsumers(sourcePath) {
+  const p = join(sourcePath, "scripts", "_bus_consumers.json");
+  try {
+    const data = JSON.parse(readFileSync(p, "utf8"));
+    const consumers = data?.consumers;
+    if (!Array.isArray(consumers)) return [];
+    return consumers.filter((c) => c?.event_filter && c?.module);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Recursively collect all .py files under dir, skipping __pycache__ dirs
+ * and files whose basename ends with _bus_consumers.py.
+ * @param {string} dir
+ * @returns {string[]} absolute file paths
+ */
+function collectPyFiles(dir) {
+  const results = [];
+  let entries;
+  try { entries = readdirSync(dir); } catch { return results; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (entry === "__pycache__") continue;
+      results.push(...collectPyFiles(full));
+    } else if (entry.endsWith(".py") && !entry.endsWith("_bus_consumers.py")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Build event→Set<producerRelpath> map by grepping scripts/**\/*.py.
+ * @param {string} sourcePath
+ * @param {Set<string>} events
+ * @returns {Map<string, Set<string>>}
+ */
+function buildProducerMap(sourcePath, events) {
+  /** @type {Map<string, Set<string>>} */
+  const map = new Map();
+  for (const ev of events) map.set(ev, new Set());
+
+  const scriptsDir = join(sourcePath, "scripts");
+  const pyFiles = collectPyFiles(scriptsDir);
+
+  for (const absPath of pyFiles) {
+    let text;
+    try { text = readFileSync(absPath, "utf8"); } catch { continue; }
+    // posix relpath relative to sourcePath
+    const rel = relative(sourcePath, absPath).split(sep).join("/");
+    // reset lastIndex between files
+    EVENT_RE.lastIndex = 0;
+    let m;
+    while ((m = EVENT_RE.exec(text)) !== null) {
+      const ev = m[1];
+      if (map.has(ev)) {
+        map.get(ev).add(rel);
+      }
+      // reset not needed between matches in same string, but be safe
+    }
+  }
+  return map;
+}
+
+/**
+ * Confirm a file node exists in the graph; return the node id or null.
+ * @param {import("better-sqlite3").Database} db
+ * @param {string} relpath
+ * @returns {string|null}
+ */
+function fileNodeId(db, relpath) {
+  const id = `file:${relpath}`;
+  const row = db.prepare("SELECT 1 FROM nodes WHERE id = ?").get(id);
+  return row ? id : null;
+}
+
+/**
+ * Extract wicked-bus producer→consumer injected edges into the codegraph DB.
+ *
+ * @param {{ db: import("better-sqlite3").Database, sourcePath: string }} opts
+ * @returns {{ edges_added: number, skipped: number, consumers: number }}
+ */
+export function extract({ db, sourcePath }) {
+  // 1. Idempotent: clear prior bus edges
+  db.prepare("DELETE FROM edges WHERE provenance = ?").run(INJECTED_PROVENANCE);
+
+  // 2. Load consumer registry
+  const consumers = readConsumers(sourcePath);
+  if (consumers.length === 0) {
+    return { edges_added: 0, skipped: 0, consumers: 0 };
+  }
+
+  // 3. Grep for producers
+  const events = new Set(consumers.map((c) => c.event_filter));
+  const producerMap = buildProducerMap(sourcePath, events);
+
+  // 4. Insert edges
+  const insertEdge = db.prepare(
+    "INSERT INTO edges (source, target, kind, metadata, provenance) VALUES (?, ?, ?, ?, ?)"
+  );
+
+  let edges_added = 0;
+  let skipped = 0;
+
+  for (const { event_filter: ev, module: consumerMod } of consumers) {
+    // Confirm consumer node exists
+    const consumerNodeId = fileNodeId(db, consumerMod);
+    if (!consumerNodeId) {
+      skipped++;
+      continue;
+    }
+
+    const producers = producerMap.get(ev) ?? new Set();
+    for (const prodRelpath of [...producers].sort()) {
+      // Don't self-link
+      if (prodRelpath === consumerMod) continue;
+
+      // Confirm producer node exists
+      const producerNodeId = fileNodeId(db, prodRelpath);
+      if (!producerNodeId) {
+        skipped++;
+        continue;
+      }
+
+      // DIRECTION: source=consumer (dependent), target=producer (dependency)
+      // blastRadius(producer) = WHERE target=producer → source=consumer ✓
+      insertEdge.run(
+        consumerNodeId,              // source = consumer (dependent)
+        producerNodeId,              // target = producer (dependency)
+        "references",
+        JSON.stringify({ injected: "bus", event: ev }),
+        INJECTED_PROVENANCE
+      );
+      edges_added++;
+    }
+  }
+
+  return { edges_added, skipped, consumers: consumers.length };
+}

--- a/server/lib/codegraph-extractors/capability.mjs
+++ b/server/lib/codegraph-extractors/capability.mjs
@@ -1,0 +1,139 @@
+/**
+ * codegraph-extractors/capability.mjs — agent→capability injected edges.
+ *
+ * An agent declares needed capabilities via a `tool-capabilities:` YAML frontmatter
+ * block list. This extractor reads those declarations and creates synthetic
+ * `capability:<name>` nodes plus edges from the agent file to each capability.
+ *
+ * Edge direction: source=agent (dependent) → target=capability (dependency).
+ * DEPENDENTS_BY="target": blastRadius(capability) = WHERE target=capability → source=agent ✓
+ *
+ * Frontmatter-only port of wicked-garden's inject_capability_edges.py.
+ * No capability registry is imported — brain stays dependency-free.
+ *
+ * This extractor OWNS the capability nodes:
+ *   - DELETE edges WHERE provenance='injected:capability'
+ *   - DELETE nodes WHERE kind='capability'
+ * then re-inserts cleanly on each run (fully idempotent).
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { ensureFileNode, ensureVirtualNode } from "../codegraph-nodes.mjs";
+
+const INJECTED_PROVENANCE = "injected:capability";
+
+// Matches the tool-capabilities: YAML block at the start or in frontmatter.
+// Captures the multi-line list body (lines starting with optional whitespace + "- item").
+const CAPS_BLOCK_RE = /(?:^|\n)tool-capabilities:\s*\n((?:[ \t]+-[ \t]*[a-z0-9_-]+[ \t]*\n?)+)/;
+
+// Matches individual list items: "  - capability-name"
+const ITEM_RE = /-[ \t]*([a-z0-9_-]+)/g;
+
+/**
+ * Extract the YAML frontmatter block (between leading --- fences) from text.
+ * Returns the frontmatter string, or the full text if no fences found.
+ * @param {string} text
+ * @returns {string}
+ */
+function extractFrontmatter(text) {
+  const match = text.match(/^---\s*\n([\s\S]*?)\n---/);
+  return match ? match[1] : "";
+}
+
+/**
+ * Parse tool-capabilities list from frontmatter text.
+ * Returns a Set of capability names (deduped).
+ * @param {string} frontmatter
+ * @returns {Set<string>}
+ */
+function parseCapabilities(frontmatter) {
+  const caps = new Set();
+  const blockMatch = CAPS_BLOCK_RE.exec(frontmatter);
+  if (!blockMatch) return caps;
+
+  const block = blockMatch[1];
+  ITEM_RE.lastIndex = 0;
+  let m;
+  while ((m = ITEM_RE.exec(block)) !== null) {
+    caps.add(m[1]);
+  }
+  return caps;
+}
+
+/**
+ * Recursively collect all .md files under dir.
+ * @param {string} dir
+ * @returns {string[]} absolute file paths
+ */
+function collectMdFiles(dir) {
+  const results = [];
+  let entries;
+  try { entries = readdirSync(dir); } catch { return results; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      results.push(...collectMdFiles(full));
+    } else if (entry.endsWith(".md")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Extract agent→capability injected edges into the codegraph DB.
+ *
+ * @param {{ db: import("better-sqlite3").Database, sourcePath: string }} opts
+ * @returns {{ edges_added: number, capabilities: number }}
+ */
+export function extract({ db, sourcePath }) {
+  // 1. Idempotent: clear prior capability edges and owned nodes
+  db.prepare("DELETE FROM edges WHERE provenance = ?").run(INJECTED_PROVENANCE);
+  db.prepare("DELETE FROM nodes WHERE kind = 'capability'").run();
+
+  const insertEdge = db.prepare(
+    "INSERT INTO edges (source, target, kind, metadata, provenance) VALUES (?, ?, ?, ?, ?)"
+  );
+
+  let edges_added = 0;
+  const distinctCaps = new Set();
+
+  // 2. Scan agents/**/*.md
+  const agentsDir = join(sourcePath, "agents");
+  const agentFiles = collectMdFiles(agentsDir);
+
+  for (const absPath of agentFiles) {
+    let text;
+    try { text = readFileSync(absPath, "utf8"); } catch { continue; }
+
+    // Posix relpath relative to sourcePath
+    const relpath = relative(sourcePath, absPath).split(sep).join("/");
+
+    // 3. Parse frontmatter capabilities (deduped per agent)
+    const frontmatter = extractFrontmatter(text);
+    const caps = parseCapabilities(frontmatter);
+    if (caps.size === 0) continue;
+
+    const src = ensureFileNode(db, relpath);
+
+    for (const cap of caps) {
+      // Ensure the capability virtual node exists
+      const tgt = ensureVirtualNode(db, `capability:${cap}`, "capability", cap);
+
+      insertEdge.run(
+        src,
+        tgt,
+        "references",
+        JSON.stringify({ injected: "capability", capability: cap }),
+        INJECTED_PROVENANCE
+      );
+      edges_added++;
+      distinctCaps.add(cap);
+    }
+  }
+
+  return { edges_added, capabilities: distinctCaps.size };
+}

--- a/server/lib/codegraph-extractors/dispatch.mjs
+++ b/server/lib/codegraph-extractors/dispatch.mjs
@@ -1,0 +1,122 @@
+/**
+ * codegraph-extractors/dispatch.mjs — command→agent injected edges.
+ *
+ * A slash command dispatches to a subagent via a `subagent_type: <plugin>:<domain>:<name>`
+ * string (in Task(subagent_type="...") or YAML frontmatter). The command file never
+ * references the agent file — grep/static can't link them. This extractor injects
+ * those edges so blast-radius traversal can surface the dispatching commands when
+ * an agent changes.
+ *
+ * Edge direction: source=command (dependent) → target=agent (dependency).
+ * DEPENDENTS_BY="target": blastRadius(agent) = WHERE target=agent → source=command ✓
+ *
+ * Port of wicked-garden's inject_dispatch_edges.py. Direction is already correct
+ * in the garden version for our blast-radius convention (no reversal needed, unlike bus).
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { ensureFileNode } from "../codegraph-nodes.mjs";
+
+const INJECTED_PROVENANCE = "injected:dispatch";
+
+// Matches subagent_type: "plugin:domain:name" or subagent_type="plugin:domain:name"
+// (with or without quotes, colon or equals separator)
+const SUBAGENT_RE = /subagent_type\s*[:=]\s*["']?([a-z0-9_-]+:[a-z0-9_-]+:[a-z0-9_-]+)["']?/g;
+
+/**
+ * Recursively collect all .md files under dir.
+ * @param {string} dir
+ * @returns {string[]} absolute file paths
+ */
+function collectMdFiles(dir) {
+  const results = [];
+  let entries;
+  try { entries = readdirSync(dir); } catch { return results; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      results.push(...collectMdFiles(full));
+    } else if (entry.endsWith(".md")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Given a handle `plugin:domain:name`, resolve to the agent relpath
+ * `agents/<domain>/<name>.md`. Returns the relpath if the file exists, else null.
+ * @param {string} sourcePath
+ * @param {string} handle  e.g. "wicked-garden:d:my-agent"
+ * @returns {string|null}
+ */
+function resolveHandle(sourcePath, handle) {
+  const parts = handle.split(":");
+  if (parts.length !== 3) return null;
+  const [, domain, name] = parts;
+  const relpath = `agents/${domain}/${name}.md`;
+  if (existsSync(join(sourcePath, relpath))) return relpath;
+  return null;
+}
+
+/**
+ * Extract command→agent dispatch injected edges into the codegraph DB.
+ *
+ * @param {{ db: import("better-sqlite3").Database, sourcePath: string }} opts
+ * @returns {{ edges_added: number, dispatches: number }}
+ */
+export function extract({ db, sourcePath }) {
+  // 1. Idempotent: clear prior dispatch edges
+  db.prepare("DELETE FROM edges WHERE provenance = ?").run(INJECTED_PROVENANCE);
+
+  const insertEdge = db.prepare(
+    "INSERT INTO edges (source, target, kind, metadata, provenance) VALUES (?, ?, ?, ?, ?)"
+  );
+
+  let edges_added = 0;
+  let dispatches = 0;
+
+  // 2. Scan commands/**/*.md
+  const commandsDir = join(sourcePath, "commands");
+  const commandFiles = collectMdFiles(commandsDir);
+
+  for (const absPath of commandFiles) {
+    let text;
+    try { text = readFileSync(absPath, "utf8"); } catch { continue; }
+
+    // Posix relpath relative to sourcePath
+    const relpath = relative(sourcePath, absPath).split(sep).join("/");
+
+    // 3. Find distinct handles in this file
+    SUBAGENT_RE.lastIndex = 0;
+    const handles = new Set();
+    let m;
+    while ((m = SUBAGENT_RE.exec(text)) !== null) {
+      handles.add(m[1]);
+    }
+
+    for (const handle of handles) {
+      // 4. Resolve handle to agent file
+      const agentRelpath = resolveHandle(sourcePath, handle);
+      if (!agentRelpath) continue; // not an agent file, or file doesn't exist
+
+      const src = ensureFileNode(db, relpath);
+      const tgt = ensureFileNode(db, agentRelpath);
+
+      insertEdge.run(
+        src,
+        tgt,
+        "references",
+        JSON.stringify({ injected: "dispatch", subagent_type: handle }),
+        INJECTED_PROVENANCE
+      );
+      edges_added++;
+      dispatches++;
+    }
+  }
+
+  return { edges_added, dispatches };
+}

--- a/server/lib/codegraph-index.mjs
+++ b/server/lib/codegraph-index.mjs
@@ -42,7 +42,10 @@ export function runIndex(sourcePath, opts = {}, _spawn = spawn) {
     if (!argv) { resolve({ ok: false, error: "codegraph not resolvable" }); return; }
     const [cmd, ...prefix] = argv;
     const sub = existsSync(dbPath(sourcePath)) ? "index" : "init";
-    const proc = _spawn(cmd, [...prefix, sub, "."], { cwd: sourcePath, stdio: ["ignore", "pipe", "pipe"] });
+    // stdout is "ignore", not "pipe": codegraph prints a progress banner and on a
+    // large repo an undrained stdout pipe can fill and deadlock the child. stderr
+    // stays piped so we can surface the failure message.
+    const proc = _spawn(cmd, [...prefix, sub, "."], { cwd: sourcePath, stdio: ["ignore", "ignore", "pipe"] });
     let stderr = "";
     proc.stderr.on("data", (d) => { stderr += d.toString(); });
     proc.on("error", (e) => resolve({ ok: false, error: e.message }));

--- a/server/lib/codegraph-index.mjs
+++ b/server/lib/codegraph-index.mjs
@@ -1,0 +1,53 @@
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { resolveCodegraph } from "./codegraph-resolver.mjs";
+
+export function dbPath(sourcePath) {
+  return join(sourcePath, ".codegraph", "codegraph.db");
+}
+
+/**
+ * How far the graph has drifted from HEAD. Fail-open: errors report
+ * present-but-unknown, never throw.
+ * @returns {{present:boolean, stale:boolean|null, commits_behind:number|null, indexed_at:string|null}}
+ */
+export function staleness(sourcePath) {
+  const db = dbPath(sourcePath);
+  if (!existsSync(db)) {
+    return { present: false, stale: null, commits_behind: null, indexed_at: null };
+  }
+  try {
+    const iso = new Date(statSync(db).mtimeMs).toISOString();
+    const out = execFileSync("git",
+      ["-C", sourcePath, "rev-list", "--count", `--since=${iso}`, "HEAD"],
+      { encoding: "utf-8", timeout: 10_000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+    const behind = out ? parseInt(out, 10) : 0;
+    return { present: true, stale: behind > 0, commits_behind: behind, indexed_at: iso };
+  } catch {
+    return { present: true, stale: null, commits_behind: null, indexed_at: null };
+  }
+}
+
+/**
+ * Build/refresh the graph by shelling codegraph. `init` bootstraps .codegraph
+ * AND indexes; `index` refreshes an existing graph (fails if .codegraph is
+ * absent) — so we pick based on db presence (pinned in docs/codegraph-contract.md).
+ * Resolves nothing -> {ok:false}. Never throws. `_spawn` is injectable for tests.
+ * @returns {Promise<{ok:boolean, subcommand?:string, error?:string}>}
+ */
+export function runIndex(sourcePath, opts = {}, _spawn = spawn) {
+  return new Promise((resolve) => {
+    const argv = resolveCodegraph({ ...opts, sourcePath });
+    if (!argv) { resolve({ ok: false, error: "codegraph not resolvable" }); return; }
+    const [cmd, ...prefix] = argv;
+    const sub = existsSync(dbPath(sourcePath)) ? "index" : "init";
+    const proc = _spawn(cmd, [...prefix, sub, "."], { cwd: sourcePath, stdio: ["ignore", "pipe", "pipe"] });
+    let stderr = "";
+    proc.stderr.on("data", (d) => { stderr += d.toString(); });
+    proc.on("error", (e) => resolve({ ok: false, error: e.message }));
+    proc.on("close", (code) =>
+      resolve(code === 0 ? { ok: true, subcommand: sub }
+                         : { ok: false, error: stderr.trim() || `exit ${code}` }));
+  });
+}

--- a/server/lib/codegraph-nodes.mjs
+++ b/server/lib/codegraph-nodes.mjs
@@ -1,0 +1,63 @@
+/**
+ * codegraph-nodes.mjs — self-noding helpers for injected-edge extractors.
+ *
+ * codegraph indexes *code* (tree-sitter parsed). Injected edges to/from .md
+ * files or virtual capability nodes need their endpoints to exist in the nodes
+ * table first. These helpers create them idempotently via INSERT OR IGNORE, so
+ * real code files codegraph already indexed are never overwritten.
+ *
+ * Port of scripts/codegraph/_graph_nodes.py, targeting the exact schema in
+ * docs/codegraph-contract.md (all NOT NULL columns populated).
+ */
+
+// Populates every NOT NULL column the codegraph `nodes` schema requires.
+// Columns with defaults (is_exported etc.) are omitted — SQLite fills them.
+const INSERT_NODE =
+  "INSERT OR IGNORE INTO nodes " +
+  "(id, kind, name, qualified_name, file_path, language, " +
+  " start_line, end_line, start_column, end_column, updated_at) " +
+  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?)";
+
+function nowMs() {
+  return Date.now();
+}
+
+/**
+ * Ensure a `file:<relpath>` node exists in the graph; return its id.
+ *
+ * For .md command/agent files that codegraph skipped, this creates a synthetic
+ * file node so dispatch/capability edges can anchor. For a real source file
+ * codegraph already indexed, INSERT OR IGNORE is a no-op (real node preserved).
+ *
+ * @param {import("better-sqlite3").Database} db - read-write Database
+ * @param {string} relpath - POSIX-relative path from repo root
+ * @param {string} [language] - language tag (default "markdown")
+ * @returns {string} the node id `file:<relpath>`
+ */
+export function ensureFileNode(db, relpath, language = "markdown") {
+  const id = `file:${relpath}`;
+  const name = relpath.split("/").pop();
+  db.prepare(INSERT_NODE).run(id, "file", name, relpath, relpath, language, 1, 1, nowMs());
+  return id;
+}
+
+/**
+ * Ensure a synthetic non-file node (e.g. `capability:<name>`) exists; return id.
+ *
+ * Populates every NOT NULL column the schema demands — the original capability
+ * insert set only id/kind/name/file_path and would violate NOT NULL constraints.
+ *
+ * @param {import("better-sqlite3").Database} db - read-write Database
+ * @param {string} id - node id (e.g. "capability:foo")
+ * @param {string} kind - node kind (e.g. "capability")
+ * @param {string} name - human-readable name
+ * @param {string|null} [filePath] - optional file_path; falls back to id
+ * @returns {string} the node id
+ */
+export function ensureVirtualNode(db, id, kind, name, filePath = null) {
+  db.prepare(INSERT_NODE).run(
+    id, kind, name, name, filePath ?? id, "virtual",
+    0, 0, nowMs()
+  );
+  return id;
+}

--- a/server/lib/codegraph-resolver.mjs
+++ b/server/lib/codegraph-resolver.mjs
@@ -1,0 +1,64 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { platform } from "node:os";
+
+const PACKAGE = "@colbymchenry/codegraph";
+
+function argvFor(target) {
+  // A .mjs/.js path is a script -> invoke via node; else run directly.
+  return /\.(mjs|js)$/.test(target) ? ["node", target] : [target];
+}
+
+function whichDefault(command) {
+  try {
+    const cmd = platform() === "win32" ? "where" : "which";
+    const out = execFileSync(cmd, [command], { encoding: "utf-8", timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"] });
+    return out.trim().split("\n")[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function configBin(brainPath) {
+  if (!brainPath) return null;
+  try {
+    const cfg = JSON.parse(readFileSync(join(brainPath, "_meta", "codegraph.json"), "utf-8"));
+    return typeof cfg.bin === "string" && cfg.bin.trim() ? cfg.bin.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the argv prefix that invokes codegraph, or null.
+ * Ladder: WICKED_CODEGRAPH_BIN (set-but-empty = kill switch) -> brain
+ * _meta/codegraph.json {bin} -> PATH -> source node_modules/.bin -> `npx`.
+ */
+export function resolveCodegraph(opts = {}) {
+  const { env = process.env, brainPath, sourcePath, which = whichDefault,
+    allowNpx = true } = opts;
+
+  if (Object.prototype.hasOwnProperty.call(env, "WICKED_CODEGRAPH_BIN")) {
+    const v = (env.WICKED_CODEGRAPH_BIN || "").trim();
+    return v ? argvFor(v) : null; // empty == kill switch
+  }
+  const cfg = configBin(brainPath);
+  if (cfg) return argvFor(cfg);
+
+  const onPath = which("codegraph");
+  if (onPath) return [onPath];
+
+  if (sourcePath) {
+    const local = join(sourcePath, "node_modules", ".bin", "codegraph");
+    if (existsSync(local)) return [local];
+  }
+  if (allowNpx && which("npx")) return ["npx", "-y", PACKAGE];
+  return null;
+}
+
+/** True iff a CONCRETE install resolves (not the npx last resort). */
+export function codegraphAvailable(opts = {}) {
+  return resolveCodegraph({ ...opts, allowNpx: false }) !== null;
+}

--- a/server/test/codegraph-actions.test.mjs
+++ b/server/test/codegraph-actions.test.mjs
@@ -48,3 +48,33 @@ test("graph-blast-radius on a graphless repo reports unavailable", () => {
     assert.equal(actions["graph-blast-radius"]({ node: "x" }).engine, "unavailable");
   } finally { rmSync(repo, { recursive: true, force: true }); }
 });
+
+// ── B5: graph-index wiring ─────────────────────────────────────────────────────
+//
+// We don't invoke real codegraph in unit tests. The kill-switch path
+// (WICKED_CODEGRAPH_BIN="") makes runIndex return {ok:false} immediately, so we
+// verify that:
+//   - graph-index returns {ok:false, ...} and does NOT throw
+//   - the result does NOT include `injected` (extractor injection is skipped on failure)
+//   - staleness is still attached
+
+test("B5: graph-index with unresolvable codegraph returns ok:false without injected, no throw", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-act-b5-"));
+  const prev = process.env.WICKED_CODEGRAPH_BIN;
+  process.env.WICKED_CODEGRAPH_BIN = "";
+  try {
+    const actions = makeGraphActions({ sourcePath: repo });
+    const result = await actions["graph-index"]();
+    assert.equal(result.ok, false, `expected ok:false, got ${JSON.stringify(result)}`);
+    assert.ok(!("injected" in result),
+      `injected must NOT be present on ok:false; got keys: ${Object.keys(result).join(", ")}`);
+    assert.ok("staleness" in result, "staleness must always be attached");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.WICKED_CODEGRAPH_BIN;
+    } else {
+      process.env.WICKED_CODEGRAPH_BIN = prev;
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-actions.test.mjs
+++ b/server/test/codegraph-actions.test.mjs
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { makeGraphActions } from "../lib/codegraph-actions.mjs";
+
+function repoWithGraph() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-act-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(`CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+    file_path TEXT, language TEXT, start_line INT, end_line INT, start_column INT,
+    end_column INT, updated_at INT, signature TEXT);
+    CREATE TABLE edges (source TEXT, target TEXT, kind TEXT, metadata TEXT, provenance TEXT);`);
+  const n = db.prepare(`INSERT INTO nodes (id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature) VALUES (?,?,?,?,?,?,1,1,0,0,0,NULL)`);
+  n.run("file:a.py","file","a.py","a.py","a.py","python");
+  n.run("file:b.py","file","b.py","b.py","b.py","python");
+  db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES (?,?,?,?,?)")
+    .run("file:b.py","file:a.py","imports",null,"static");  // b depends on a
+  db.close();
+  return repo;
+}
+
+test("graph-blast-radius action returns dependents", () => {
+  const repo = repoWithGraph();
+  try {
+    const actions = makeGraphActions({ sourcePath: repo });
+    const r = actions["graph-blast-radius"]({ node: "file:a.py" });
+    assert.deepEqual(r.dependents.map((d) => d.id), ["file:b.py"]);
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("graph-callers and graph-lineage are wired", () => {
+  const repo = repoWithGraph();
+  try {
+    const actions = makeGraphActions({ sourcePath: repo });
+    assert.deepEqual(actions["graph-callers"]({ node: "file:a.py" }).callers.map((d)=>d.id), ["file:b.py"]);
+    assert.deepEqual(actions["graph-lineage"]({ node: "file:b.py" }).dependencies.map((d)=>d.id), ["file:a.py"]);
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("graph-blast-radius on a graphless repo reports unavailable", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-none-"));
+  try {
+    const actions = makeGraphActions({ sourcePath: repo });
+    assert.equal(actions["graph-blast-radius"]({ node: "x" }).engine, "unavailable");
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});

--- a/server/test/codegraph-bus.test.mjs
+++ b/server/test/codegraph-bus.test.mjs
@@ -1,0 +1,222 @@
+/**
+ * codegraph-bus.test.mjs — B2: bus producer->consumer edge extractor
+ *
+ * Direction: source=consumer (dependent), target=producer (dependency)
+ * DEPENDENTS_BY="target", so blastRadius(producer) finds WHERE target=producer → source=consumer.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { CodegraphClient } from "../lib/codegraph-client.mjs";
+import { extract } from "../lib/codegraph-extractors/bus.mjs";
+
+// Real DDL from docs/codegraph-contract.md
+const REAL_NODES_DDL = `
+CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    qualified_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    start_column INTEGER NOT NULL,
+    end_column INTEGER NOT NULL,
+    docstring TEXT,
+    signature TEXT,
+    visibility TEXT,
+    is_exported INTEGER DEFAULT 0,
+    is_async INTEGER DEFAULT 0,
+    is_static INTEGER DEFAULT 0,
+    is_abstract INTEGER DEFAULT 0,
+    decorators TEXT,
+    type_parameters TEXT,
+    updated_at INTEGER NOT NULL
+)`;
+
+const REAL_EDGES_DDL = `
+CREATE TABLE edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    metadata TEXT,
+    line INTEGER,
+    col INTEGER,
+    provenance TEXT DEFAULT NULL,
+    FOREIGN KEY (source) REFERENCES nodes(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES nodes(id) ON DELETE CASCADE
+)`;
+
+function insertFileNode(db, relpath, language = "python") {
+  db.prepare(`INSERT OR IGNORE INTO nodes
+    (id, kind, name, qualified_name, file_path, language,
+     start_line, end_line, start_column, end_column, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, 1, 1, 0, 0, ?)`)
+    .run(`file:${relpath}`, "file", relpath.split("/").pop(), relpath, relpath, language, Date.now());
+}
+
+function makeFixture() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-bus-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  mkdirSync(join(repo, "scripts"), { recursive: true });
+
+  // Create the DB with real schema
+  const dbPath = join(repo, ".codegraph", "codegraph.db");
+  const db = new Database(dbPath);
+  db.exec(REAL_NODES_DDL);
+  db.exec(REAL_EDGES_DDL);
+
+  // Insert the two file nodes
+  insertFileNode(db, "scripts/producer.py");
+  insertFileNode(db, "scripts/consumer.py");
+  db.close();
+
+  // Write bus consumers registry
+  writeFileSync(
+    join(repo, "scripts", "_bus_consumers.json"),
+    JSON.stringify({
+      consumers: [
+        { event_filter: "wicked.thing.happened", module: "scripts/consumer.py" }
+      ]
+    })
+  );
+
+  // Write producer file
+  writeFileSync(
+    join(repo, "scripts", "producer.py"),
+    'emit_event("wicked.thing.happened")\n'
+  );
+
+  return { repo, dbPath };
+}
+
+test("extract adds 1 bus edge, correct direction: source=consumer, target=producer", () => {
+  const { repo, dbPath } = makeFixture();
+  try {
+    const db = new Database(dbPath);
+    const result = extract({ db, sourcePath: repo });
+    db.close();
+
+    assert.equal(result.edges_added, 1, `expected 1 edge, got ${result.edges_added}`);
+    assert.equal(result.skipped, 0);
+    assert.equal(result.consumers, 1);
+
+    // Verify edge direction: source=consumer (dependent), target=producer (dependency)
+    const readDb = new Database(dbPath, { readonly: true });
+    const edge = readDb.prepare(
+      "SELECT source, target, kind, provenance, metadata FROM edges WHERE provenance = ?"
+    ).get("injected:bus");
+    readDb.close();
+
+    assert.ok(edge, "edge must exist");
+    assert.equal(edge.source, "file:scripts/consumer.py",
+      "source must be the consumer (dependent)");
+    assert.equal(edge.target, "file:scripts/producer.py",
+      "target must be the producer (dependency)");
+    assert.equal(edge.kind, "references");
+    assert.equal(edge.provenance, "injected:bus");
+
+    const meta = JSON.parse(edge.metadata);
+    assert.equal(meta.event, "wicked.thing.happened");
+    assert.equal(meta.injected, "bus");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("end-to-end direction proof: blastRadius(producer) surfaces consumer as dependent", () => {
+  const { repo, dbPath } = makeFixture();
+  try {
+    // Write edges
+    const db = new Database(dbPath);
+    extract({ db, sourcePath: repo });
+    db.close();
+
+    // Use CodegraphClient (readonly) to verify blast-radius
+    const c = new CodegraphClient(repo);
+    const r = c.blastRadius({ node: "file:scripts/producer.py" });
+    c.close();
+
+    const ids = r.dependents.map((d) => d.id);
+    assert.ok(
+      ids.includes("file:scripts/consumer.py"),
+      `consumer must appear in blast-radius of producer; got: ${JSON.stringify(ids)}`
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("extract is idempotent — re-run leaves exactly 1 bus edge (no dupes)", () => {
+  const { repo, dbPath } = makeFixture();
+  try {
+    const db1 = new Database(dbPath);
+    extract({ db: db1, sourcePath: repo });
+    db1.close();
+
+    const db2 = new Database(dbPath);
+    extract({ db: db2, sourcePath: repo });
+    db2.close();
+
+    const readDb = new Database(dbPath, { readonly: true });
+    const count = readDb.prepare(
+      "SELECT COUNT(*) AS c FROM edges WHERE provenance = ?"
+    ).get("injected:bus").c;
+    readDb.close();
+
+    assert.equal(count, 1, `expected exactly 1 bus edge after 2 runs, got ${count}`);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("extract returns zero when _bus_consumers.json is missing", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-bus-empty-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  mkdirSync(join(repo, "scripts"), { recursive: true });
+  const dbPath = join(repo, ".codegraph", "codegraph.db");
+  const db = new Database(dbPath);
+  db.exec(REAL_NODES_DDL);
+  db.exec(REAL_EDGES_DDL);
+
+  const result = extract({ db, sourcePath: repo });
+  db.close();
+
+  assert.equal(result.edges_added, 0);
+  assert.equal(result.consumers, 0);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("extract skips consumer when its node does not exist in the graph", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-bus-skip-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  mkdirSync(join(repo, "scripts"), { recursive: true });
+  const dbPath = join(repo, ".codegraph", "codegraph.db");
+  const db = new Database(dbPath);
+  db.exec(REAL_NODES_DDL);
+  db.exec(REAL_EDGES_DDL);
+  // Only insert producer, NOT consumer
+  insertFileNode(db, "scripts/producer.py");
+
+  writeFileSync(
+    join(repo, "scripts", "_bus_consumers.json"),
+    JSON.stringify({
+      consumers: [
+        { event_filter: "wicked.thing.happened", module: "scripts/consumer.py" }
+      ]
+    })
+  );
+  writeFileSync(join(repo, "scripts", "producer.py"), 'emit_event("wicked.thing.happened")\n');
+
+  const result = extract({ db, sourcePath: repo });
+  db.close();
+
+  assert.equal(result.edges_added, 0);
+  assert.equal(result.skipped, 1);
+  rmSync(repo, { recursive: true, force: true });
+});

--- a/server/test/codegraph-capability.test.mjs
+++ b/server/test/codegraph-capability.test.mjs
@@ -1,0 +1,273 @@
+/**
+ * codegraph-capability.test.mjs — B3: capability (agent→cap) injected-edge extractor
+ *
+ * Tests the extract() function in codegraph-extractors/capability.mjs.
+ * Uses the real nodes/edges DDL from docs/codegraph-contract.md.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { extract } from "../lib/codegraph-extractors/capability.mjs";
+import { CodegraphClient } from "../lib/codegraph-client.mjs";
+
+// Real DDL from docs/codegraph-contract.md
+const NODES_DDL = `
+CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    qualified_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    start_column INTEGER NOT NULL,
+    end_column INTEGER NOT NULL,
+    docstring TEXT,
+    signature TEXT,
+    visibility TEXT,
+    is_exported INTEGER DEFAULT 0,
+    is_async INTEGER DEFAULT 0,
+    is_static INTEGER DEFAULT 0,
+    is_abstract INTEGER DEFAULT 0,
+    decorators TEXT,
+    type_parameters TEXT,
+    updated_at INTEGER NOT NULL
+)`;
+
+const EDGES_DDL = `
+CREATE TABLE edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    metadata TEXT,
+    line INTEGER,
+    col INTEGER,
+    provenance TEXT DEFAULT NULL,
+    FOREIGN KEY (source) REFERENCES nodes(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES nodes(id) ON DELETE CASCADE
+)`;
+
+/**
+ * Create a temp repo directory with .codegraph/codegraph.db
+ * Returns { repo, db } — caller must db.close() and rmSync(repo).
+ */
+function makeRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-capability-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(NODES_DDL);
+  db.exec(EDGES_DDL);
+  return { repo, db };
+}
+
+/** Write a file, creating its parent directory. */
+function writeFile(repo, relpath, content) {
+  const abs = join(repo, relpath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content, "utf8");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("capability: agent with tool-capabilities frontmatter → 2 edges and 2 cap nodes", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "agents/d/a.md", `---
+tool-capabilities:
+  - security-scanning
+  - version-control
+---
+# Agent A
+`);
+
+    const result = extract({ db, sourcePath: repo });
+
+    assert.equal(result.edges_added, 2, "two capability edges");
+    assert.equal(result.capabilities, 2, "two distinct capability nodes created");
+
+    const edges = db.prepare(
+      "SELECT * FROM edges WHERE provenance = 'injected:capability' ORDER BY target"
+    ).all();
+    assert.equal(edges.length, 2);
+
+    const targets = edges.map((e) => e.target).sort();
+    assert.deepEqual(targets, [
+      "capability:security-scanning",
+      "capability:version-control",
+    ]);
+
+    for (const edge of edges) {
+      assert.equal(edge.source, "file:agents/d/a.md");
+      assert.equal(edge.kind, "references");
+      assert.equal(edge.provenance, "injected:capability");
+      const meta = JSON.parse(edge.metadata);
+      assert.equal(meta.injected, "capability");
+      assert.ok(typeof meta.capability === "string");
+    }
+
+    // Verify the capability nodes exist in the nodes table
+    const capNodes = db.prepare(
+      "SELECT id, kind, name FROM nodes WHERE kind = 'capability' ORDER BY id"
+    ).all();
+    assert.equal(capNodes.length, 2);
+    assert.equal(capNodes[0].id, "capability:security-scanning");
+    assert.equal(capNodes[1].id, "capability:version-control");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability: idempotent — re-run produces no duplicate edges or nodes", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "agents/d/a.md", `---
+tool-capabilities:
+  - security-scanning
+  - version-control
+---
+# Agent A
+`);
+
+    extract({ db, sourcePath: repo });
+    extract({ db, sourcePath: repo }); // second call
+
+    const edgeCount = db.prepare(
+      "SELECT COUNT(*) AS c FROM edges WHERE provenance = 'injected:capability'"
+    ).get().c;
+    assert.equal(edgeCount, 2, "idempotent — still exactly 2 edges");
+
+    const nodeCount = db.prepare(
+      "SELECT COUNT(*) AS c FROM nodes WHERE kind = 'capability'"
+    ).get().c;
+    assert.equal(nodeCount, 2, "idempotent — still exactly 2 capability nodes");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability: agent without tool-capabilities → no edges", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "agents/x/no-caps.md", `---
+description: an agent with no capability declarations
+---
+# No Caps Agent
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 0);
+    assert.equal(result.capabilities, 0);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability: no agent files → empty result", () => {
+  const { repo, db } = makeRepo();
+  try {
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 0);
+    assert.equal(result.capabilities, 0);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability: duplicate cap items in same agent are deduped", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "agents/d/a.md", `---
+tool-capabilities:
+  - security-scanning
+  - security-scanning
+  - version-control
+---
+# Agent A
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 2, "duplicates within same agent deduped → 2 edges");
+    assert.equal(result.capabilities, 2);
+
+    const edgeCount = db.prepare(
+      "SELECT COUNT(*) AS c FROM edges WHERE provenance = 'injected:capability'"
+    ).get().c;
+    assert.equal(edgeCount, 2);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability: multiple agents sharing a cap → one node, multiple edges", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "agents/a/agent1.md", `---
+tool-capabilities:
+  - security-scanning
+---
+# Agent 1
+`);
+    writeFile(repo, "agents/b/agent2.md", `---
+tool-capabilities:
+  - security-scanning
+---
+# Agent 2
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 2, "two edges — one per agent");
+    assert.equal(result.capabilities, 1, "only one distinct capability node");
+
+    const nodeCount = db.prepare(
+      "SELECT COUNT(*) AS c FROM nodes WHERE id = 'capability:security-scanning'"
+    ).get().c;
+    assert.equal(nodeCount, 1);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability: end-to-end blastRadius — capability surfaces the declaring agent", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "agents/d/a.md", `---
+tool-capabilities:
+  - security-scanning
+  - version-control
+---
+# Agent A
+`);
+
+    extract({ db, sourcePath: repo });
+    db.close(); // close write handle before opening read-only client
+
+    const client = new CodegraphClient(repo);
+    try {
+      const result = client.blastRadius({ node: "capability:security-scanning" });
+      assert.ok(Array.isArray(result.dependents), "dependents must be an array");
+      const ids = result.dependents.map((n) => n.id);
+      assert.ok(
+        ids.includes("file:agents/d/a.md"),
+        `Expected file:agents/d/a.md in blast-radius dependents; got: ${JSON.stringify(ids)}`
+      );
+    } finally {
+      client.close();
+    }
+  } finally {
+    // db already closed above
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-client.test.mjs
+++ b/server/test/codegraph-client.test.mjs
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { CodegraphClient } from "../lib/codegraph-client.mjs";
+
+function makeRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-client-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(`
+    CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+      file_path TEXT, language TEXT, start_line INT, end_line INT,
+      start_column INT, end_column INT, updated_at INT, signature TEXT);
+    CREATE TABLE edges (source TEXT, target TEXT, kind TEXT, metadata TEXT, provenance TEXT);
+  `);
+  const n = db.prepare(`INSERT INTO nodes
+    (id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature)
+    VALUES (?,?,?,?,?,?,?,?,0,0,0,?)`);
+  n.run("file:a.py", "file", "a.py", "a.py", "a.py", "python", 1, 1, null);
+  n.run("file:b.py", "file", "b.py", "b.py", "b.py", "python", 1, 2, null);
+  n.run("file:c.py", "file", "c.py", "c.py", "c.py", "python", 1, 2, null);
+  // edge(source=dependent, target=dependency): b depends on a, c depends on b
+  const e = db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES (?,?,?,?,?)");
+  e.run("file:b.py", "file:a.py", "imports", null, "static");
+  e.run("file:c.py", "file:b.py", "calls", null, "static");
+  db.close();
+  return repo;
+}
+
+test("blastRadius returns transitive dependents of a node", () => {
+  const repo = makeRepo();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.blastRadius({ node: "file:a.py" });
+    assert.deepEqual(r.dependents.map((d) => d.id).sort(), ["file:b.py", "file:c.py"]);
+    assert.equal(r.staleness.present, true);
+    c.close();
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("callers returns direct dependents only", () => {
+  const repo = makeRepo();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.callers({ node: "file:a.py" });
+    assert.deepEqual(r.callers.map((d) => d.id), ["file:b.py"]);
+    c.close();
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("lineage returns transitive dependencies (downstream)", () => {
+  const repo = makeRepo();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.lineage({ node: "file:c.py" });
+    assert.deepEqual(r.dependencies.map((d) => d.id).sort(), ["file:a.py", "file:b.py"]);
+    c.close();
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("missing db -> engine unavailable, not an empty graph", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-empty-"));
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.blastRadius({ node: "file:a.py" });
+    assert.equal(r.engine, "unavailable");
+    c.close();
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("a cycle does not infinite-loop", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-cycle-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(`CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+    file_path TEXT, language TEXT, start_line INT, end_line INT, start_column INT,
+    end_column INT, updated_at INT, signature TEXT);
+    CREATE TABLE edges (source TEXT, target TEXT, kind TEXT, metadata TEXT, provenance TEXT);`);
+  const n = db.prepare(`INSERT INTO nodes (id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature) VALUES (?,?,?,?,?,?,1,1,0,0,0,NULL)`);
+  n.run("file:x.py","file","x.py","x.py","x.py","python"); n.run("file:y.py","file","y.py","y.py","y.py","python");
+  const e = db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES (?,?,?,?,?)");
+  e.run("file:x.py","file:y.py","calls",null,"static"); e.run("file:y.py","file:x.py","calls",null,"static");
+  db.close();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.blastRadius({ node: "file:x.py" });
+    assert.deepEqual(r.dependents.map((d) => d.id).sort(), ["file:y.py"]);
+    c.close();
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});

--- a/server/test/codegraph-dispatch.test.mjs
+++ b/server/test/codegraph-dispatch.test.mjs
@@ -1,0 +1,234 @@
+/**
+ * codegraph-dispatch.test.mjs — B3: dispatch (command→agent) injected-edge extractor
+ *
+ * Tests the extract() function in codegraph-extractors/dispatch.mjs.
+ * Uses the real nodes/edges DDL from docs/codegraph-contract.md.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { extract } from "../lib/codegraph-extractors/dispatch.mjs";
+import { CodegraphClient } from "../lib/codegraph-client.mjs";
+import { dbPath } from "../lib/codegraph-index.mjs";
+
+// Real DDL from docs/codegraph-contract.md
+const NODES_DDL = `
+CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    qualified_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    start_column INTEGER NOT NULL,
+    end_column INTEGER NOT NULL,
+    docstring TEXT,
+    signature TEXT,
+    visibility TEXT,
+    is_exported INTEGER DEFAULT 0,
+    is_async INTEGER DEFAULT 0,
+    is_static INTEGER DEFAULT 0,
+    is_abstract INTEGER DEFAULT 0,
+    decorators TEXT,
+    type_parameters TEXT,
+    updated_at INTEGER NOT NULL
+)`;
+
+const EDGES_DDL = `
+CREATE TABLE edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    metadata TEXT,
+    line INTEGER,
+    col INTEGER,
+    provenance TEXT DEFAULT NULL,
+    FOREIGN KEY (source) REFERENCES nodes(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES nodes(id) ON DELETE CASCADE
+)`;
+
+/**
+ * Create a temp repo directory with .codegraph/codegraph.db
+ * Returns { repo, db } — caller must db.close() and rmSync(repo).
+ */
+function makeRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-dispatch-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(NODES_DDL);
+  db.exec(EDGES_DDL);
+  return { repo, db };
+}
+
+/** Write a file, creating its parent directory. */
+function writeFile(repo, relpath, content) {
+  const abs = join(repo, relpath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content, "utf8");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("dispatch: command with matching agent → one edge inserted", () => {
+  const { repo, db } = makeRepo();
+  try {
+    // Create the command file with a subagent_type reference
+    writeFile(repo, "commands/d/c.md", `
+# My Command
+
+Task(subagent_type="wicked-garden:d:a")
+`);
+    // Create the corresponding agent file
+    writeFile(repo, "agents/d/a.md", "# Agent A");
+
+    const result = extract({ db, sourcePath: repo });
+
+    assert.equal(result.edges_added, 1, "one edge should be added");
+    assert.equal(result.dispatches, 1, "one dispatch resolved");
+
+    const edges = db.prepare("SELECT * FROM edges WHERE provenance = 'injected:dispatch'").all();
+    assert.equal(edges.length, 1);
+
+    const edge = edges[0];
+    assert.equal(edge.source, "file:commands/d/c.md");
+    assert.equal(edge.target, "file:agents/d/a.md");
+    assert.equal(edge.kind, "references");
+    assert.equal(edge.provenance, "injected:dispatch");
+
+    const meta = JSON.parse(edge.metadata);
+    assert.equal(meta.injected, "dispatch");
+    assert.equal(meta.subagent_type, "wicked-garden:d:a");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch: handle with no matching agent file is skipped", () => {
+  const { repo, db } = makeRepo();
+  try {
+    // Command references two handles: one existing agent, one ghost
+    writeFile(repo, "commands/d/c.md", `
+Task(subagent_type="wicked-garden:d:a")
+Task(subagent_type="wicked-garden:d:ghost")
+`);
+    writeFile(repo, "agents/d/a.md", "# Agent A");
+    // agents/d/ghost.md does NOT exist
+
+    const result = extract({ db, sourcePath: repo });
+
+    assert.equal(result.edges_added, 1, "ghost handle must be skipped — only 1 edge");
+    assert.equal(result.dispatches, 1, "only the resolved handle counts");
+
+    const edges = db.prepare("SELECT * FROM edges WHERE provenance = 'injected:dispatch'").all();
+    assert.equal(edges.length, 1);
+    assert.equal(edges[0].target, "file:agents/d/a.md");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch: idempotent — re-run does not duplicate edges", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "commands/d/c.md", 'Task(subagent_type="wicked-garden:d:a")');
+    writeFile(repo, "agents/d/a.md", "# Agent A");
+
+    extract({ db, sourcePath: repo });
+    extract({ db, sourcePath: repo }); // second call
+
+    const count = db.prepare(
+      "SELECT COUNT(*) AS c FROM edges WHERE provenance = 'injected:dispatch'"
+    ).get().c;
+    assert.equal(count, 1, "idempotent — still exactly 1 edge after two runs");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch: no command files → empty result", () => {
+  const { repo, db } = makeRepo();
+  try {
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 0);
+    assert.equal(result.dispatches, 0);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch: YAML frontmatter subagent_type is also matched", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "commands/x/cmd.md", `---
+subagent_type: wicked-garden:x:worker
+---
+# Command
+`);
+    writeFile(repo, "agents/x/worker.md", "# Worker agent");
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 1);
+    assert.equal(result.dispatches, 1);
+
+    const edge = db.prepare("SELECT * FROM edges WHERE provenance = 'injected:dispatch'").get();
+    assert.equal(edge.source, "file:commands/x/cmd.md");
+    assert.equal(edge.target, "file:agents/x/worker.md");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch: same handle in multiple commands → one edge per command", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "commands/a/c1.md", 'Task(subagent_type="wicked-garden:a:agent")');
+    writeFile(repo, "commands/a/c2.md", 'Task(subagent_type="wicked-garden:a:agent")');
+    writeFile(repo, "agents/a/agent.md", "# Agent");
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 2, "one edge per command file that dispatches");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch: end-to-end blastRadius — agent surfaces the dispatching command", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "commands/d/c.md", 'Task(subagent_type="wicked-garden:d:a")');
+    writeFile(repo, "agents/d/a.md", "# Agent A");
+
+    extract({ db, sourcePath: repo });
+    db.close(); // close write handle before opening read-only client
+
+    const client = new CodegraphClient(repo);
+    try {
+      const result = client.blastRadius({ node: "file:agents/d/a.md" });
+      assert.ok(Array.isArray(result.dependents), "dependents must be an array");
+      const ids = result.dependents.map((n) => n.id);
+      assert.ok(
+        ids.includes("file:commands/d/c.md"),
+        `Expected file:commands/d/c.md in blast-radius dependents; got: ${JSON.stringify(ids)}`
+      );
+    } finally {
+      client.close();
+    }
+  } finally {
+    // db already closed above
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-dispatch.test.mjs
+++ b/server/test/codegraph-dispatch.test.mjs
@@ -14,7 +14,6 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { extract } from "../lib/codegraph-extractors/dispatch.mjs";
 import { CodegraphClient } from "../lib/codegraph-client.mjs";
-import { dbPath } from "../lib/codegraph-index.mjs";
 
 // Real DDL from docs/codegraph-contract.md
 const NODES_DDL = `

--- a/server/test/codegraph-extract.test.mjs
+++ b/server/test/codegraph-extract.test.mjs
@@ -245,3 +245,56 @@ test("B4-discoverDropins: broken dropin import is skipped, valid one included", 
     rmSync(repo, { recursive: true, force: true });
   }
 });
+
+test("B4-5: drop-in self-noding via passed nodes helpers — no brain import needed", async () => {
+  const { repo, dbFile } = makeBusWiredRepo();
+  try {
+    const dropinDir = join(repo, ".codegraph-extractors");
+    mkdirSync(dropinDir, { recursive: true });
+
+    // A drop-in that uses only the passed `nodes` helpers — no brain imports.
+    writeFileSync(
+      join(dropinDir, "demo.mjs"),
+      `export function extract({ db, sourcePath, nodes }) {
+  const a = nodes.ensureVirtualNode(db, "thing:demo", "thing", "demo");
+  const f = nodes.ensureFileNode(db, "x/y.md");
+  db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES (?,?,?,?,?)")
+    .run(f, a, "references", null, "dropin:demo");
+  return { edges_added: 1 };
+}
+`,
+    );
+
+    const db = new Database(dbFile);
+    const result = await runExtractors({ db, sourcePath: repo });
+
+    // The virtual node thing:demo must exist
+    const vNode = db.prepare("SELECT * FROM nodes WHERE id = ?").get("thing:demo");
+    assert.ok(vNode, "thing:demo virtual node must exist");
+    assert.equal(vNode.kind, "thing");
+    assert.equal(vNode.name, "demo");
+
+    // The file node file:x/y.md must exist
+    const fNode = db.prepare("SELECT * FROM nodes WHERE id = ?").get("file:x/y.md");
+    assert.ok(fNode, "file:x/y.md file node must exist");
+    assert.equal(fNode.kind, "file");
+
+    // The dropin:demo edge must exist
+    const edge = db.prepare(
+      "SELECT * FROM edges WHERE provenance = 'dropin:demo'"
+    ).get();
+    assert.ok(edge, "dropin:demo edge must exist");
+    assert.equal(edge.source, "file:x/y.md");
+    assert.equal(edge.target, "thing:demo");
+    assert.equal(edge.kind, "references");
+
+    // The result must reflect the dropin ran
+    assert.ok("dropin:demo.mjs" in result,
+      `result must have dropin:demo.mjs key; got: ${Object.keys(result).join(", ")}`);
+    assert.equal(result["dropin:demo.mjs"].edges_added, 1);
+
+    db.close();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-extract.test.mjs
+++ b/server/test/codegraph-extract.test.mjs
@@ -1,0 +1,247 @@
+/**
+ * codegraph-extract.test.mjs — B4: extractor registry (builtins + drop-ins)
+ *
+ * Cases:
+ *  1. builtins run: a repo wired for the bus extractor → runExtractors returns
+ *     a `bus` entry with edges_added >= 1; total_injected_edges >= 1; dropins is [].
+ *  2. dropin discovered + run: a dropin .mjs file is imported and called.
+ *  3. absent dropin dir → only builtin labels, dropins: [].
+ *  4. fail-open: a dropin that throws → its entry is {error:...}, other extractors still ran.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+
+import { discoverDropins, runExtractors } from "../lib/codegraph-extract.mjs";
+
+// ── Real DDL (from docs/codegraph-contract.md) ────────────────────────────────
+
+const REAL_NODES_DDL = `
+CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    qualified_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    start_column INTEGER NOT NULL,
+    end_column INTEGER NOT NULL,
+    docstring TEXT,
+    signature TEXT,
+    visibility TEXT,
+    is_exported INTEGER DEFAULT 0,
+    is_async INTEGER DEFAULT 0,
+    is_static INTEGER DEFAULT 0,
+    is_abstract INTEGER DEFAULT 0,
+    decorators TEXT,
+    type_parameters TEXT,
+    updated_at INTEGER NOT NULL
+)`;
+
+const REAL_EDGES_DDL = `
+CREATE TABLE edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    metadata TEXT,
+    line INTEGER,
+    col INTEGER,
+    provenance TEXT DEFAULT NULL,
+    FOREIGN KEY (source) REFERENCES nodes(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES nodes(id) ON DELETE CASCADE
+)`;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function insertFileNode(db, relpath, language = "python") {
+  db.prepare(`INSERT OR IGNORE INTO nodes
+    (id, kind, name, qualified_name, file_path, language,
+     start_line, end_line, start_column, end_column, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, 1, 1, 0, 0, ?)`)
+    .run(`file:${relpath}`, "file", relpath.split("/").pop(), relpath, relpath, language, Date.now());
+}
+
+/**
+ * Build a repo dir with a .codegraph/codegraph.db (real DDL), scripts/ with
+ * a bus producer + consumer wiring. Returns { repo, dbPath }.
+ */
+function makeBusWiredRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-ext-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  mkdirSync(join(repo, "scripts"), { recursive: true });
+
+  const dbFile = join(repo, ".codegraph", "codegraph.db");
+  const db = new Database(dbFile);
+  db.exec(REAL_NODES_DDL);
+  db.exec(REAL_EDGES_DDL);
+  insertFileNode(db, "scripts/producer.py");
+  insertFileNode(db, "scripts/consumer.py");
+  db.close();
+
+  writeFileSync(
+    join(repo, "scripts", "_bus_consumers.json"),
+    JSON.stringify({
+      consumers: [
+        { event_filter: "wicked.thing.happened", module: "scripts/consumer.py" },
+      ],
+    }),
+  );
+  writeFileSync(
+    join(repo, "scripts", "producer.py"),
+    'emit_event("wicked.thing.happened")\n',
+  );
+
+  return { repo, dbFile };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test("B4-1: builtins run — bus extractor adds edges_added >= 1, dropins is []", async () => {
+  const { repo, dbFile } = makeBusWiredRepo();
+  try {
+    const db = new Database(dbFile);
+    const result = await runExtractors({ db, sourcePath: repo });
+    db.close();
+
+    assert.ok(result.bus, "bus key must be present");
+    assert.ok(result.bus.edges_added >= 1,
+      `bus.edges_added must be >= 1, got ${result.bus.edges_added}`);
+    assert.ok(result.total_injected_edges >= 1,
+      `total_injected_edges must be >= 1, got ${result.total_injected_edges}`);
+    assert.deepEqual(result.dropins, [], "no dropins expected");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("B4-2: dropin discovered + run — marker.mjs adds 1 edge; dropins includes it", async () => {
+  const { repo, dbFile } = makeBusWiredRepo();
+  try {
+    // Write a drop-in extractor
+    const dropinDir = join(repo, ".codegraph-extractors");
+    mkdirSync(dropinDir, { recursive: true });
+    // NOTE: this imports and runs code from the target repo — by design (trusted repo extractors)
+    writeFileSync(
+      join(dropinDir, "marker.mjs"),
+      `export function extract({db}) {
+  db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES ('file:scripts/producer.py','file:scripts/consumer.py','references',null,'dropin:marker')").run();
+  return { edges_added: 1 };
+}
+`,
+    );
+
+    const db = new Database(dbFile);
+    const result = await runExtractors({ db, sourcePath: repo });
+    db.close();
+
+    assert.ok("dropin:marker.mjs" in result,
+      `result must have dropin:marker.mjs key; got keys: ${Object.keys(result).join(", ")}`);
+    assert.equal(result["dropin:marker.mjs"].edges_added, 1);
+    assert.ok(result.dropins.includes("dropin:marker.mjs"),
+      `dropins must include dropin:marker.mjs; got: ${JSON.stringify(result.dropins)}`);
+    assert.ok(result.total_injected_edges >= 1,
+      `total_injected_edges must count dropin; got ${result.total_injected_edges}`);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("B4-3: absent dropin dir — only builtin labels, dropins is []", async () => {
+  const { repo, dbFile } = makeBusWiredRepo();
+  try {
+    const db = new Database(dbFile);
+    const result = await runExtractors({ db, sourcePath: repo });
+    db.close();
+
+    // Builtin labels must be present
+    assert.ok("bus" in result, "bus key must be present");
+    assert.ok("dispatch" in result, "dispatch key must be present");
+    assert.ok("capability" in result, "capability key must be present");
+    assert.deepEqual(result.dropins, []);
+    // No extra unknown keys beyond builtins + meta
+    const knownMeta = new Set(["total_injected_edges", "dropins"]);
+    const builtinLabels = new Set(["bus", "dispatch", "capability"]);
+    for (const k of Object.keys(result)) {
+      assert.ok(knownMeta.has(k) || builtinLabels.has(k),
+        `unexpected key in result: ${k}`);
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("B4-4: fail-open — a throwing dropin leaves {error} entry; builtin labels still present", async () => {
+  const { repo, dbFile } = makeBusWiredRepo();
+  try {
+    const dropinDir = join(repo, ".codegraph-extractors");
+    mkdirSync(dropinDir, { recursive: true });
+    writeFileSync(
+      join(dropinDir, "broken.mjs"),
+      `export function extract() { throw new Error("intentional failure"); }\n`,
+    );
+
+    const db = new Database(dbFile);
+    const result = await runExtractors({ db, sourcePath: repo });
+    db.close();
+
+    // The broken dropin must have an error entry
+    assert.ok("dropin:broken.mjs" in result,
+      `result must have dropin:broken.mjs key; got: ${Object.keys(result).join(", ")}`);
+    assert.ok(typeof result["dropin:broken.mjs"].error === "string",
+      "error must be a string");
+    assert.ok(result["dropin:broken.mjs"].error.length > 0,
+      "error must be non-empty");
+
+    // Builtins must still be present and have counts (not error)
+    assert.ok("bus" in result, "bus key must still be present");
+    assert.ok(!("error" in result.bus), `bus must not have error; got: ${JSON.stringify(result.bus)}`);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("B4-discoverDropins: absent dir returns []", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-ext-empty-"));
+  try {
+    const result = await discoverDropins(repo);
+    assert.deepEqual(result, []);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("B4-discoverDropins: broken dropin import is skipped, valid one included", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-ext-di-"));
+  try {
+    const dropinDir = join(repo, ".codegraph-extractors");
+    mkdirSync(dropinDir, { recursive: true });
+
+    // Valid dropin
+    writeFileSync(
+      join(dropinDir, "valid.mjs"),
+      `export function extract() { return { edges_added: 0 }; }\n`,
+    );
+    // Broken dropin (syntax error via bad import)
+    writeFileSync(
+      join(dropinDir, "broken.mjs"),
+      `THIS IS NOT VALID JS\n`,
+    );
+
+    const result = await discoverDropins(repo);
+    const labels = result.map((d) => d.label);
+    assert.ok(labels.includes("dropin:valid.mjs"),
+      `valid.mjs should be discovered; got: ${JSON.stringify(labels)}`);
+    assert.ok(!labels.includes("dropin:broken.mjs"),
+      "broken.mjs must be skipped");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-index.test.mjs
+++ b/server/test/codegraph-index.test.mjs
@@ -56,7 +56,7 @@ test("runIndex uses `init` when no graph exists yet", async () => {
     const cap = {};
     const r = await runIndex(repo, { env: { WICKED_CODEGRAPH_BIN: "codegraph" } }, fakeSpawn(cap));
     assert.equal(r.ok, true);
-    assert.equal(cap.args[0], "init");
+    assert.ok(cap.args.includes("init"), `expected 'init' in ${cap.args}`);
     assert.equal(cap.opts.cwd, repo);
   } finally {
     rmSync(repo, { recursive: true, force: true });
@@ -71,7 +71,7 @@ test("runIndex uses `index` when a graph already exists", async () => {
     const cap = {};
     const r = await runIndex(repo, { env: { WICKED_CODEGRAPH_BIN: "codegraph" } }, fakeSpawn(cap));
     assert.equal(r.ok, true);
-    assert.equal(cap.args[0], "index");
+    assert.ok(cap.args.includes("index"), `expected 'index' in ${cap.args}`);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/server/test/codegraph-index.test.mjs
+++ b/server/test/codegraph-index.test.mjs
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EventEmitter } from "node:events";
+import { execFileSync } from "node:child_process";
+import { dbPath, staleness, runIndex } from "../lib/codegraph-index.mjs";
+
+test("dbPath points at <source>/.codegraph/codegraph.db", () => {
+  assert.equal(dbPath("/repo"), join("/repo", ".codegraph", "codegraph.db"));
+});
+
+test("staleness reports not-present when db is missing", () => {
+  const s = staleness("/no/such/repo");
+  assert.equal(s.present, false);
+  assert.equal(s.stale, null);
+});
+
+test("staleness reports commits behind HEAD", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-stale-"));
+  try {
+    const git = (...a) => execFileSync("git", ["-C", repo, ...a], { stdio: "pipe" });
+    git("init", "-b", "main"); git("config", "user.email", "t@t"); git("config", "user.name", "t");
+    writeFileSync(join(repo, "f.txt"), "1"); git("add", "-A"); git("commit", "-m", "c1");
+    mkdirSync(join(repo, ".codegraph"), { recursive: true });
+    const db = join(repo, ".codegraph", "codegraph.db");
+    writeFileSync(db, "x");
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(db, past, past);          // backdate the db before a 2nd commit
+    writeFileSync(join(repo, "g.txt"), "2"); git("add", "-A"); git("commit", "-m", "c2");
+    const s = staleness(repo);
+    assert.equal(s.present, true);
+    assert.equal(s.stale, true);
+    assert.ok(s.commits_behind >= 1);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// runIndex chooses init vs index based on whether the graph db already exists.
+// Inject a fake spawn so we assert the subcommand WITHOUT invoking real codegraph.
+function fakeSpawn(captured) {
+  return (cmd, args, opts) => {
+    captured.cmd = cmd; captured.args = args; captured.opts = opts;
+    const p = new EventEmitter();
+    p.stderr = new EventEmitter();
+    queueMicrotask(() => p.emit("close", 0));
+    return p;
+  };
+}
+
+test("runIndex uses `init` when no graph exists yet", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-init-"));
+  try {
+    const cap = {};
+    const r = await runIndex(repo, { env: { WICKED_CODEGRAPH_BIN: "codegraph" } }, fakeSpawn(cap));
+    assert.equal(r.ok, true);
+    assert.equal(cap.args[0], "init");
+    assert.equal(cap.opts.cwd, repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("runIndex uses `index` when a graph already exists", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-idx-"));
+  try {
+    mkdirSync(join(repo, ".codegraph"), { recursive: true });
+    writeFileSync(join(repo, ".codegraph", "codegraph.db"), "x");
+    const cap = {};
+    const r = await runIndex(repo, { env: { WICKED_CODEGRAPH_BIN: "codegraph" } }, fakeSpawn(cap));
+    assert.equal(r.ok, true);
+    assert.equal(cap.args[0], "index");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("runIndex returns ok:false when codegraph is unresolvable", async () => {
+  const r = await runIndex("/tmp", { env: { WICKED_CODEGRAPH_BIN: "" } });  // kill switch
+  assert.equal(r.ok, false);
+  assert.match(r.error, /not resolvable/);
+});

--- a/server/test/codegraph-nodes.test.mjs
+++ b/server/test/codegraph-nodes.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * codegraph-nodes.test.mjs — B1: self-noding helpers
+ *
+ * Uses the EXACT real DDL from docs/codegraph-contract.md to validate INSERTs
+ * against the real NOT NULL constraints.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { ensureFileNode, ensureVirtualNode } from "../lib/codegraph-nodes.mjs";
+
+// Real DDL from docs/codegraph-contract.md — validates INSERTs against actual NOT NULL constraints
+const REAL_NODES_DDL = `
+CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    qualified_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    start_column INTEGER NOT NULL,
+    end_column INTEGER NOT NULL,
+    docstring TEXT,
+    signature TEXT,
+    visibility TEXT,
+    is_exported INTEGER DEFAULT 0,
+    is_async INTEGER DEFAULT 0,
+    is_static INTEGER DEFAULT 0,
+    is_abstract INTEGER DEFAULT 0,
+    decorators TEXT,
+    type_parameters TEXT,
+    updated_at INTEGER NOT NULL
+)`;
+
+function makeDb() {
+  const dir = mkdtempSync(join(tmpdir(), "cg-nodes-"));
+  const db = new Database(join(dir, "test.db"));
+  db.exec(REAL_NODES_DDL);
+  return { db, dir };
+}
+
+test("ensureFileNode inserts a file node with id file:<relpath>", () => {
+  const { db, dir } = makeDb();
+  try {
+    const id = ensureFileNode(db, "commands/x.md");
+    assert.equal(id, "file:commands/x.md");
+    const row = db.prepare("SELECT * FROM nodes WHERE id = ?").get("file:commands/x.md");
+    assert.ok(row, "row must exist");
+    assert.equal(row.kind, "file");
+    assert.equal(row.language, "markdown");
+    assert.equal(row.start_line, 1);
+    assert.equal(row.end_line, 1);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureFileNode is idempotent — second call is a no-op (count stays 1)", () => {
+  const { db, dir } = makeDb();
+  try {
+    ensureFileNode(db, "commands/x.md");
+    ensureFileNode(db, "commands/x.md");
+    const count = db.prepare("SELECT COUNT(*) AS c FROM nodes WHERE id = ?")
+      .get("file:commands/x.md").c;
+    assert.equal(count, 1);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureVirtualNode inserts a virtual node and is idempotent", () => {
+  const { db, dir } = makeDb();
+  try {
+    const id = ensureVirtualNode(db, "capability:foo", "capability", "foo");
+    assert.equal(id, "capability:foo");
+    const row = db.prepare("SELECT * FROM nodes WHERE id = ?").get("capability:foo");
+    assert.ok(row, "row must exist");
+    assert.equal(row.kind, "capability");
+    assert.equal(row.name, "foo");
+    // idempotent
+    ensureVirtualNode(db, "capability:foo", "capability", "foo");
+    const count = db.prepare("SELECT COUNT(*) AS c FROM nodes WHERE id = ?")
+      .get("capability:foo").c;
+    assert.equal(count, 1);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("INSERT OR IGNORE does not overwrite a pre-existing real node", () => {
+  const { db, dir } = makeDb();
+  try {
+    // Pre-insert a real code node with a distinct name
+    db.prepare(`INSERT INTO nodes
+      (id, kind, name, qualified_name, file_path, language,
+       start_line, end_line, start_column, end_column, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0)`)
+      .run("file:a.py", "file", "ORIGINAL_NAME", "a.py", "a.py", "python", 1, 100);
+
+    // Call ensureFileNode — must be a no-op
+    const id = ensureFileNode(db, "a.py");
+    assert.equal(id, "file:a.py");
+
+    const row = db.prepare("SELECT name, end_line FROM nodes WHERE id = ?").get("file:a.py");
+    assert.equal(row.name, "ORIGINAL_NAME", "original name must be preserved");
+    assert.equal(row.end_line, 100, "original end_line must be preserved");
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureFileNode accepts explicit language override", () => {
+  const { db, dir } = makeDb();
+  try {
+    ensureFileNode(db, "scripts/foo.py", "python");
+    const row = db.prepare("SELECT language FROM nodes WHERE id = ?").get("file:scripts/foo.py");
+    assert.equal(row.language, "python");
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-nodes.test.mjs
+++ b/server/test/codegraph-nodes.test.mjs
@@ -6,7 +6,7 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";

--- a/server/test/codegraph-resolver.test.mjs
+++ b/server/test/codegraph-resolver.test.mjs
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveCodegraph } from "../lib/codegraph-resolver.mjs";
+
+test("env override wins and is split into argv", () => {
+  const argv = resolveCodegraph({ env: { WICKED_CODEGRAPH_BIN: "/opt/cg" } });
+  assert.deepEqual(argv, ["/opt/cg"]);
+});
+
+test("a .mjs/.js env target is invoked via node", () => {
+  const argv = resolveCodegraph({ env: { WICKED_CODEGRAPH_BIN: "/x/cg.mjs" } });
+  assert.deepEqual(argv, ["node", "/x/cg.mjs"]);
+});
+
+test("set-but-empty env is the kill switch -> null", () => {
+  assert.equal(resolveCodegraph({ env: { WICKED_CODEGRAPH_BIN: "" } }), null);
+});
+
+test("brain config _meta/codegraph.json bin is honored", () => {
+  const brain = mkdtempSync(join(tmpdir(), "cg-cfg-"));
+  mkdirSync(join(brain, "_meta"), { recursive: true });
+  writeFileSync(join(brain, "_meta", "codegraph.json"), JSON.stringify({ bin: "/cfg/cg" }));
+  try {
+    const argv = resolveCodegraph({ env: {}, brainPath: brain, which: () => null });
+    assert.deepEqual(argv, ["/cfg/cg"]);
+  } finally {
+    rmSync(brain, { recursive: true, force: true });
+  }
+});
+
+test("falls back to npx when nothing else resolves", () => {
+  const argv = resolveCodegraph({ env: {}, which: (c) => (c === "npx" ? "/usr/bin/npx" : null) });
+  assert.deepEqual(argv, ["npx", "-y", "@colbymchenry/codegraph"]);
+});
+
+test("no npx and nothing resolves -> null", () => {
+  assert.equal(resolveCodegraph({ env: {}, which: () => null }), null);
+});

--- a/skills/wicked-brain-graph/SKILL.md
+++ b/skills/wicked-brain-graph/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: wicked-brain:graph
+description: |
+  Code-relationship graph queries — blast radius, callers, and lineage — backed
+  by a codegraph static graph the brain owns. Answers "what breaks if I change X",
+  "who calls X", and "what does X depend on" across the whole repo, including
+  relationships a grep or single-file LSP lookup cannot see.
+
+  Use when: "blast radius", "what breaks if I change", "impact of changing X",
+  "who depends on X", "what depends on X", "lineage", "what does X depend on",
+  "architecture map", "code relationship graph".
+---
+
+# wicked-brain:graph
+
+Relationship-graph intelligence over a codegraph-built SQLite graph. Distinct from
+`wicked-brain:lsp` (live, single-symbol definitions / references / hover /
+diagnostics) — this is the whole-repo relationship graph and the home of
+blast-radius / lineage.
+
+## Cross-Platform Notes
+
+This skill uses `npx wicked-brain-call` for all server interaction. The CLI works
+on macOS, Linux, and Windows; it discovers the brain, auto-starts the server, and
+writes a per-call audit record under `{brain}/calls/`.
+
+## Queries
+
+- `graph-index` — build/refresh the graph (`codegraph init`/`index`). Run once per
+  repo, then on demand when a result reports it is stale.
+- `graph-blast-radius {node}` — transitive **dependents** of `node` ("what breaks
+  if I change it").
+- `graph-callers {node}` — direct dependents only (depth 1).
+- `graph-lineage {node}` — transitive **dependencies** (what `node` depends on,
+  downstream).
+
+`node` ids follow codegraph's convention — e.g. `file:src/app.py`, or a symbol id
+like `function:<hash>` (use `qualified_name` from a search/symbols lookup to find
+the id). Every result carries a `staleness` stamp (`commits_behind`, `indexed_at`);
+when `stale` is true, re-run `graph-index`.
+
+## Freshness
+
+Lazy by design — the graph is **never** auto-rebuilt by a file watcher (that path
+is a known CPU-runaway hazard). Results tell you when they are behind HEAD; rebuild
+explicitly with `graph-index` (or wire the optional commit hook). If codegraph is
+not installed, queries return `engine: "unavailable"` rather than a misleading
+empty graph.
+
+## Engine
+
+Backed by the `@colbymchenry/codegraph` CLI (resolved at runtime via
+`WICKED_CODEGRAPH_BIN` → brain config → PATH → `npx`). The brain reads codegraph's
+SQLite graph directly; it shells the CLI only to (re)build.

--- a/skills/wicked-brain-lsp/SKILL.md
+++ b/skills/wicked-brain-lsp/SKILL.md
@@ -6,13 +6,17 @@ description: |
   language servers when missing.
 
   Use when: "where is X defined", "who uses X", "what type is X",
-  "list symbols in", "find symbol", "who calls X", "blast radius",
-  "architecture map", "code diagnostics", "lsp health".
+  "list symbols in", "find symbol", "who calls X",
+  "code diagnostics", "lsp health".
 ---
 
 # wicked-brain:lsp
 
 Universal code intelligence for any CLI/IDE via the brain's LSP client layer.
+
+> For whole-repo **relationship** queries — blast radius, lineage, architecture
+> map — use `wicked-brain:graph` (codegraph-backed). LSP here is live,
+> single-symbol intelligence (definitions, references, hover, diagnostics).
 
 ## Cross-Platform Notes
 


### PR DESCRIPTION
## What
Phase 1a of moving the code-relationship graph into wicked-brain (so any repo gets it without wicked-garden). Brain shells `@colbymchenry/codegraph` to build a per-repo SQLite graph and reads it directly via better-sqlite3 to serve new `graph-*` actions + a `wicked-brain:graph` skill.

## Modules
- `codegraph-resolver.mjs` — CLI resolution ladder (env→config→PATH→node_modules→npx) + kill switch.
- `codegraph-index.mjs` — `dbPath`, `staleness` (commits-behind HEAD), `runIndex` (`init` bootstraps + indexes; `index` refreshes — pinned by a characterization spike).
- `codegraph-client.mjs` — `blastRadius`/`callers`/`lineage` via BFS over edges. Edges stored consumer→producer (`DEPENDENTS_BY="target"`, empirically pinned). Cycle-guarded. Missing db → `engine:"unavailable"`, never a vacuous empty graph.
- `codegraph-actions.mjs` + server wiring — `graph-index` (write), `graph-blast-radius`/`graph-callers`/`graph-lineage` (read).
- `wicked-brain:graph` skill; blast-radius/architecture moved off the lsp skill.

## Freshness (no watcher)
Lazy staleness-stamp; the graph is never auto-rebuilt by the file watcher (that path is a known CPU-runaway hazard). Every result carries `commits_behind`/`indexed_at`.

## Tests
373/373 server tests pass (17 new). End-to-end live-server smoke: real codegraph DB → `graph-blast-radius` surfaces the caller as a dependent, `graph-index`, staleness stamp.

## Follow-ons
Phase 1b (injected edges + extractor registry), Phase 2 (wicked-garden side). Design: wicked-garden `docs/specs/2026-06-10-codegraph-to-brain-migration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)