### PR TITLE
chore: require Node >=20 to match better-sqlite3@12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "wicked-brain-server": "server/bin/wicked-brain-server.mjs"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/base64-js": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "release": "npm version patch && git push && git push --tags"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
`better-sqlite3@^12` is a runtime **dependency** and requires Node ≥ 20, but
`engines.node` still declared `>=18.0.0` — so a consumer on Node 18 couldn't
actually run this package (the native binding can't build/load on 18).

- `engines.node`: `>=18.0.0` → `>=20.0.0` (+ lockfile mirror synced).
- No dependency, version, or source changes.
- CI already runs on `lts/*` (≥ 20), so this only makes the declaration honest.

Mirrors the same fix applied to wicked-bus. Note: consumers still on Node 18–19
will now see an `EBADENGINE` warning (intentional — Node 18 is EOL and
better-sqlite3@12 needs ≥ 20).

Full suite (406 tests) passes on Node 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)