### PR TITLE
fix: brain_id reconciliation on data path + de-flake (v0.15.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "description": "Digital brain as skills for AI coding CLIs — no vector DB, no embeddings, no infrastructure",
   "keywords": [

--- a/server/bin/wicked-brain-call.mjs
+++ b/server/bin/wicked-brain-call.mjs
@@ -161,6 +161,28 @@ async function healthInfo(port, { timeoutMs = 800 } = {}) {
   }
 }
 
+// Raised by ensureServer when a server answers the persisted port but it
+// belongs to a DIFFERENT brain than the one we resolved. The data path
+// (search/index/remove/forget/query/...) routes through ensureServer, so this
+// guard is the single choke point that stops a destructive op from silently
+// hitting the wrong brain on a shared/recycled port. Fail closed — never
+// operate on a mismatched brain.
+class PortConflictError extends Error {
+  constructor({ port, expectedBrainId, actualBrainId }) {
+    super(
+      `port_conflict: port ${port} is held by a different brain ` +
+        `(expected brain_id "${expectedBrainId}", got "${actualBrainId ?? "unknown"}"). ` +
+        `Refusing the operation so it can't hit the wrong brain. ` +
+        `Stop the other server, free the port, or pass the correct --port for this brain.`,
+    );
+    this.name = "PortConflictError";
+    this.code = "port_conflict";
+    this.port = port;
+    this.expectedBrainId = expectedBrainId;
+    this.actualBrainId = actualBrainId ?? null;
+  }
+}
+
 // ---------- spawn lock ----------
 // Cross-platform exclusive-create lock via { flag: "wx" }. Stale entries
 // (older than STALE_LOCK_MS) are reaped on contention so a crashed CLI
@@ -233,12 +255,42 @@ function openServerLog(brainPath) {
   }
 }
 
+// Reconcile the responding server's brain_id against the brain we resolved.
+// Returns true when the port is ours (or when expectedBrainId is unknown and
+// we choose not to gate). Throws PortConflictError when a DIFFERENT brain
+// answers — the fail-closed path that protects the data plane. One health
+// round-trip per resolution; cheap enough that we don't cache across calls
+// (each CLI invocation resolves the server exactly once anyway).
+function reconcileHealth(health, { port, expectedBrainId }) {
+  // No expected id to compare against (no brain.json id, no basename) — can't
+  // meaningfully gate, so don't. In practice readExpectedBrainId always yields
+  // at least the basename, so this is a defensive fallback only.
+  if (!expectedBrainId) return true;
+  if (health.brain_id === expectedBrainId) return true;
+  throw new PortConflictError({
+    port,
+    expectedBrainId,
+    actualBrainId: health.brain_id,
+  });
+}
+
 async function ensureServer(brainPath, opts) {
   const { explicitPort, sourceOverride, noSpawn, log, spawnTimeoutMs = 10_000 } = opts;
   const meta = readMetaConfig(brainPath);
   const port = explicitPort || meta.server_port || 4242;
+  // The brain we EXPECT on this port — same source --status/--stop reconcile
+  // against (brain.json `id`, falling back to the per-project basename).
+  const expectedBrainId = opts.expectedBrainId ?? readExpectedBrainId(brainPath);
 
-  if (await healthCheck(port)) return port;
+  // Warm path: a server already answers the port. Confirm it's OUR brain before
+  // handing the port to the data plane. A foreign brain can occupy this port
+  // (stale config, manual restart, EADDRINUSE probe-up), and routing by port
+  // alone would let a destructive op (remove/forget) silently hit it.
+  const warmHealth = await healthInfo(port);
+  if (warmHealth) {
+    reconcileHealth(warmHealth, { port, expectedBrainId });
+    return port;
+  }
   if (noSpawn) {
     throw new Error(`server not reachable on port ${port} and --no-spawn was set`);
   }
@@ -248,14 +300,26 @@ async function ensureServer(brainPath, opts) {
 
   if (!tryLock(lockPath)) {
     log(`another process is starting the server; waiting...`);
-    if (await waitForHealth(port, spawnTimeoutMs)) return port;
+    const concurrentHealth = await waitForHealthInfo(port, spawnTimeoutMs);
+    if (concurrentHealth) {
+      // The peer that held the lock brought a server up — confirm it's OUR
+      // brain before we route the data plane at it.
+      reconcileHealth(concurrentHealth, { port, expectedBrainId });
+      return port;
+    }
     throw new Error(`concurrent spawn timed out on port ${port}`);
   }
 
   try {
     // Re-check after acquiring the lock — another process might have started
-    // and finished while we were contending.
-    if (await healthCheck(port)) return port;
+    // and finished while we were contending. Reconcile brain_id here too: the
+    // server that came up while we waited could be a different brain probing up
+    // onto this port.
+    const relockHealth = await healthInfo(port);
+    if (relockHealth) {
+      reconcileHealth(relockHealth, { port, expectedBrainId });
+      return port;
+    }
 
     const pidPath = join(brainPath, "_meta", "server.pid");
     if (existsSync(pidPath)) {
@@ -299,7 +363,14 @@ async function ensureServer(brainPath, opts) {
     }
     if (logFd !== null) log(`server logs -> ${logPath}`);
 
-    if (await waitForHealth(port, spawnTimeoutMs)) return port;
+    const ready = await waitForHealthInfo(port, spawnTimeoutMs);
+    if (ready) {
+      // We spawned with --brain brainPath, so the server that comes up should
+      // be ours. Reconcile anyway: a foreign brain could have won the bind in
+      // the race window before our child listened. Fail closed if so.
+      reconcileHealth(ready, { port, expectedBrainId });
+      return port;
+    }
     throw new Error(
       `server did not become ready within ${spawnTimeoutMs}ms on port ${port}` +
         (logFd !== null ? ` — see ${logPath} for the cause` : ""),
@@ -316,6 +387,18 @@ async function waitForHealth(port, timeoutMs) {
     await sleep(150);
   }
   return false;
+}
+
+// Like waitForHealth but returns the health body (carrying brain_id) once the
+// port answers, so the spawn path can confirm WHICH brain came up.
+async function waitForHealthInfo(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const h = await healthInfo(port, { timeoutMs: 500 });
+    if (h) return h;
+    await sleep(150);
+  }
+  return null;
 }
 
 function sleep(ms) {
@@ -644,13 +727,43 @@ Examples:
     }
   }
 
-  const port = await ensureServer(brainPath, {
-    explicitPort: args.flags.port,
-    sourceOverride: args.flags.source,
-    noSpawn: args.flags.noSpawn,
-    spawnTimeoutMs: args.flags.spawnTimeoutMs,
-    log,
-  }).catch(err => die(err.message));
+  let port;
+  try {
+    port = await ensureServer(brainPath, {
+      explicitPort: args.flags.port,
+      sourceOverride: args.flags.source,
+      noSpawn: args.flags.noSpawn,
+      spawnTimeoutMs: args.flags.spawnTimeoutMs,
+      log,
+    });
+  } catch (err) {
+    if (err instanceof PortConflictError) {
+      // Fail closed: the persisted port is held by a different brain. Refuse the
+      // op (read OR mutate) so a destructive call (remove/forget/index) can't
+      // silently hit the wrong brain. Emit a structured payload on stdout that
+      // mirrors --stop/--status, plus a non-zero exit for scripted callers.
+      const payload = {
+        error: err.message,
+        action,
+        refused: true,
+        reason: "port_conflict",
+        port: err.port,
+        brain_id: err.expectedBrainId,
+        actual_brain_id: err.actualBrainId,
+      };
+      // Leave a refusal breadcrumb so the audit trail shows the op was blocked.
+      if (auditEnabled(args.flags.noAudit)) {
+        const a = writeAuditOpen(brainPath, action, params, err.port);
+        writeAuditClose(a, { exitCode: 1, durationMs: 0, response: payload, error: err.message });
+      }
+      process.stdout.write(
+        (args.flags.pretty ? JSON.stringify(payload, null, 2) : JSON.stringify(payload)) + "\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    die(err.message);
+  }
 
   // Open audit BEFORE the call so a crash mid-flight still leaves a partial
   // record. Audit is best-effort — write failures never block the request.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain-server",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "description": "SQLite FTS5 search server for wicked-brain digital knowledge bases",
   "keywords": [

--- a/server/test/server.test.mjs
+++ b/server/test/server.test.mjs
@@ -3,13 +3,23 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const serverBin = join(__dirname, "..", "bin", "wicked-brain-server.mjs");
 
-const port = Math.floor(4200 + Math.random() * 800);
+// Assigned in before() from an OS-allocated ephemeral port. Was previously a
+// fixed random port (Math.floor(4200 + random*800)) chosen at module load —
+// node --test runs test FILES in parallel by default, so two files (or two CI
+// shards) could land on the same number, and the server runs with an explicit
+// --port (bind-or-fail, no upward probe). The loser crashed on EADDRINUSE and
+// every test in this file then flaked as ECONNREFUSED. We now ask the OS for a
+// free port immediately before spawn and retry the spawn if the port was
+// snatched in the (small) gap between release and bind — fixing the race
+// rather than masking it with longer sleeps or retried assertions.
+let port;
 let serverProcess;
 let brainDir;
 
@@ -22,6 +32,90 @@ async function api(port, action, params = {}) {
   return res.json();
 }
 
+// Ask the OS for a free port: bind 0, read the assigned port, release. The
+// window between release and the server's bind is small; the spawn loop below
+// retries with a fresh port if it loses that race.
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port: p } = srv.address();
+      srv.close(() => resolve(p));
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// Poll the health endpoint until it answers (server is up) or the deadline
+// passes. Replaces the unconditional 1.5s sleep, which both under-waited on a
+// slow CI box and over-waited locally.
+async function waitForHealthy(p, timeoutMs = 8000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://localhost:${p}/api`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "health", params: {} }),
+      });
+      const body = await res.json();
+      if (body && body.status === "ok") return true;
+    } catch {
+      // not up yet
+    }
+    await sleep(100);
+  }
+  return false;
+}
+
+// Spawn the server on an ephemeral port, retrying with a fresh port if the
+// process dies before answering health (the EADDRINUSE race). Returns the
+// live process + the port it bound.
+async function spawnServer(brainDir, { extraArgs = [] } = {}) {
+  const MAX_ATTEMPTS = 5;
+  let lastErr = "";
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const p = await freePort();
+    const proc = spawn(
+      process.execPath,
+      [serverBin, "--brain", brainDir, "--port", String(p), ...extraArgs],
+      { stdio: "pipe" },
+    );
+    let stderrBuf = "";
+    let exited = false;
+    let exitCode = null;
+    proc.stderr.on("data", (d) => { stderrBuf += d.toString(); });
+    proc.on("exit", (code) => { exited = true; exitCode = code; });
+
+    if (await waitForHealthy(p)) {
+      // Keep surfacing late crashes for diagnostics.
+      proc.on("exit", (code) => {
+        if (code !== null && code !== 0 && stderrBuf) {
+          process.stderr.write(`[server.test] spawned server exited ${code}:\n${stderrBuf}\n`);
+        }
+      });
+      return { proc, port: p };
+    }
+
+    // Didn't become healthy. If it died on a port collision, retry on a new
+    // port; otherwise surface the failure.
+    try { proc.kill("SIGKILL"); } catch {}
+    lastErr = stderrBuf;
+    if (exited && /EADDRINUSE/.test(stderrBuf)) {
+      continue; // race lost — try a fresh ephemeral port
+    }
+    // Non-collision failure (or never exited but never healthy) — don't spin.
+    throw new Error(
+      `server did not become healthy on port ${p} (attempt ${attempt + 1}, exitCode=${exitCode}):\n${stderrBuf}`,
+    );
+  }
+  throw new Error(`server never bound a free port after ${MAX_ATTEMPTS} attempts:\n${lastErr}`);
+}
+
 before(async () => {
   // Create a temp brain directory
   brainDir = mkdtempSync(join(tmpdir(), "fs-brain-test-"));
@@ -31,23 +125,9 @@ before(async () => {
     JSON.stringify({ id: "test-brain-server" })
   );
 
-  // Spawn the server
-  serverProcess = spawn(process.execPath, [serverBin, "--brain", brainDir, "--port", String(port)], {
-    stdio: "pipe",
-  });
-
-  // Capture stderr so a crashed spawn surfaces its error on test failure
-  // instead of looking like a generic ECONNREFUSED. Printed on process exit.
-  let stderrBuf = "";
-  serverProcess.stderr.on("data", (d) => { stderrBuf += d.toString(); });
-  serverProcess.on("exit", (code) => {
-    if (code !== null && code !== 0 && stderrBuf) {
-      process.stderr.write(`[server.test] spawned server exited ${code}:\n${stderrBuf}\n`);
-    }
-  });
-
-  // Wait ~1.5s for server to start
-  await new Promise((resolve) => setTimeout(resolve, 1500));
+  const started = await spawnServer(brainDir);
+  serverProcess = started.proc;
+  port = started.port;
 });
 
 after(() => {
@@ -226,19 +306,19 @@ test("reonboard action indexes content files from disk", async () => {
 });
 
 test("--read-only flag blocks write + destructive actions (separate server)", async () => {
-  // Spin up a second server on a different port with --read-only. Verifies
-  // the gate is wired at the API dispatch layer, not just the UI.
-  const { spawn } = await import("node:child_process");
+  // Spin up a second server on its OWN ephemeral port with --read-only.
+  // Verifies the gate is wired at the API dispatch layer, not just the UI.
+  // Previously this used `port + 1`, which (a) could collide with another
+  // listener and (b) tied its fate to the first server's port — the same
+  // bind-or-fail flake. Use the robust spawn helper instead.
   const { mkdtempSync, mkdirSync: mk, writeFileSync: wf } = await import("node:fs");
   const { join: j } = await import("node:path");
   const { tmpdir: td } = await import("node:os");
   const roDir = mkdtempSync(j(td(), "ro-brain-"));
   mk(j(roDir, "_meta"), { recursive: true });
   wf(j(roDir, "brain.json"), JSON.stringify({ id: "ro-brain" }));
-  const roPort = port + 1;
-  const proc = spawn(process.execPath, [serverBin, "--brain", roDir, "--port", String(roPort), "--read-only"], { stdio: "pipe" });
+  const { proc, port: roPort } = await spawnServer(roDir, { extraArgs: ["--read-only"] });
   try {
-    await new Promise((r) => setTimeout(r, 1200));
     const h = await api(roPort, "health");
     assert.equal(h.read_only, true);
 

--- a/server/test/wicked-brain-call.test.mjs
+++ b/server/test/wicked-brain-call.test.mjs
@@ -251,23 +251,35 @@ test("concurrent cold starts converge on a single server (lock works)", async ()
 // brain_id — same response shape as the real server (db.health()). Lets us
 // simulate "a DIFFERENT brain occupies this port" without spawning two real
 // servers or touching live brain data.
+//
+// Non-health actions are RECORDED (so a test can prove whether a data op was
+// actually routed to this server) and answered with a benign ok payload. This
+// is the canary for the data-path guard: if the brain_id reconciliation works,
+// a mismatched op must be refused BEFORE it reaches here, so `received` stays
+// empty for the mutating action.
 function startFakeBrainServer(brainId) {
   return new Promise((resolve) => {
+    const received = [];
     const srv = createHttpServer((req, res) => {
       let body = "";
       req.on("data", (c) => { body += c; });
       req.on("end", () => {
-        let action = "";
-        try { action = JSON.parse(body || "{}").action; } catch {}
+        let parsed = {};
+        try { parsed = JSON.parse(body || "{}"); } catch {}
+        const action = parsed.action || "";
         res.setHeader("Content-Type", "application/json");
         if (action === "health") {
           res.end(JSON.stringify({ status: "ok", uptime: 1, brain_id: brainId }));
         } else {
-          res.end(JSON.stringify({ error: "unsupported in fake server" }));
+          received.push(parsed);
+          // Echo a benign success so a CORRECTLY-routed op looks like it landed.
+          res.end(JSON.stringify({ ok: true, fake_brain_id: brainId, action }));
         }
       });
     });
-    srv.listen(0, "127.0.0.1", () => resolve({ srv, port: srv.address().port }));
+    srv.listen(0, "127.0.0.1", () =>
+      resolve({ srv, port: srv.address().port, received }),
+    );
   });
 }
 
@@ -339,6 +351,117 @@ test("--stop REFUSES when a DIFFERENT brain occupies the port", async () => {
     assert.equal(r.parsed.brain_id, "alpha");
     assert.equal(r.parsed.actual_brain_id, "beta");
     assert.equal(r.status, 1, `expected refusal exit 1, got ${r.status}`);
+  } finally {
+    await new Promise((r) => srv.close(r));
+  }
+});
+
+// ---- data-path brain_id guard (P0: route by port alone was destructive) ----
+// The data plane (search/index/remove/forget/query/...) resolves the server via
+// ensureServer and then POSTs the action. Before the guard, ensureServer
+// confirmed only that SOMETHING healthy answered the persisted port — not that
+// it was the EXPECTED brain. A recycled/shared port could route a destructive
+// op (remove/forget) to the WRONG brain. These tests pin the fail-closed guard.
+
+test("data path: mutating op (remove) REFUSES with port_conflict on a mismatched brain", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "wb-mismatch-remove-"));
+  mkdirSync(join(dir, "_meta"), { recursive: true });
+  // We are brain "alpha"...
+  writeFileSync(join(dir, "brain.json"), JSON.stringify({ id: "alpha" }));
+  // ...but port is held by brain "beta". A remove here would nuke beta's doc.
+  const { srv, port: occupiedPort, received } = await startFakeBrainServer("beta");
+  try {
+    const r = await runCliAsync([
+      "--brain", dir,
+      "--port", String(occupiedPort),
+      "--no-spawn", // make sure we test the WARM-path guard, not a spawn
+      "remove",
+      "--param", "id=victim-doc",
+    ]);
+    assert.ok(r.parsed, `remove not JSON: ${r.stdout} ${r.stderr}`);
+    assert.equal(r.parsed.refused, true, "mutating op must be refused on mismatch");
+    assert.equal(r.parsed.reason, "port_conflict");
+    assert.equal(r.parsed.brain_id, "alpha", "should report the EXPECTED brain id");
+    assert.equal(r.parsed.actual_brain_id, "beta", "should surface the ACTUAL occupant");
+    assert.equal(r.status, 1, `expected refusal exit 1, got ${r.status}`);
+    // The destructive call must NOT have reached the foreign server.
+    const sawRemove = received.some((m) => m.action === "remove");
+    assert.equal(sawRemove, false, "remove leaked to the wrong brain — guard failed");
+  } finally {
+    await new Promise((r) => srv.close(r));
+  }
+});
+
+test("data path: mutating op (index) REFUSES with port_conflict on a mismatched brain", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "wb-mismatch-index-"));
+  mkdirSync(join(dir, "_meta"), { recursive: true });
+  writeFileSync(join(dir, "brain.json"), JSON.stringify({ id: "alpha" }));
+  const { srv, port: occupiedPort, received } = await startFakeBrainServer("beta");
+  try {
+    const r = await runCliAsync([
+      "--brain", dir,
+      "--port", String(occupiedPort),
+      "--no-spawn",
+      "index",
+      "--param", "id=x",
+      "--param", "path=x.md",
+      "--param", "content=should not land on beta",
+    ]);
+    assert.ok(r.parsed, `index not JSON: ${r.stdout} ${r.stderr}`);
+    assert.equal(r.parsed.refused, true, "index must be refused on mismatch");
+    assert.equal(r.parsed.reason, "port_conflict");
+    assert.equal(r.status, 1);
+    const sawIndex = received.some((m) => m.action === "index");
+    assert.equal(sawIndex, false, "index leaked to the wrong brain — guard failed");
+  } finally {
+    await new Promise((r) => srv.close(r));
+  }
+});
+
+test("data path: read op (search) also refuses on a mismatched brain (fail closed)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "wb-mismatch-search-"));
+  mkdirSync(join(dir, "_meta"), { recursive: true });
+  writeFileSync(join(dir, "brain.json"), JSON.stringify({ id: "alpha" }));
+  const { srv, port: occupiedPort, received } = await startFakeBrainServer("beta");
+  try {
+    const r = await runCliAsync([
+      "--brain", dir,
+      "--port", String(occupiedPort),
+      "--no-spawn",
+      "search",
+      "--param", "query=anything",
+    ]);
+    assert.ok(r.parsed, `search not JSON: ${r.stdout} ${r.stderr}`);
+    assert.equal(r.parsed.reason, "port_conflict", "reads fail closed on mismatch");
+    assert.equal(r.status, 1);
+    const sawSearch = received.some((m) => m.action === "search");
+    assert.equal(sawSearch, false, "search leaked to the wrong brain — guard failed");
+  } finally {
+    await new Promise((r) => srv.close(r));
+  }
+});
+
+test("data path: matching brain_id lets the op THROUGH to the server", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "wb-match-data-"));
+  mkdirSync(join(dir, "_meta"), { recursive: true });
+  // We are brain "gamma" and the port is held by brain "gamma" — same brain.
+  writeFileSync(join(dir, "brain.json"), JSON.stringify({ id: "gamma" }));
+  const { srv, port: occupiedPort, received } = await startFakeBrainServer("gamma");
+  try {
+    const r = await runCliAsync([
+      "--brain", dir,
+      "--port", String(occupiedPort),
+      "--no-spawn",
+      "remove",
+      "--param", "id=ok-to-remove",
+    ]);
+    assert.ok(r.parsed, `remove not JSON: ${r.stdout} ${r.stderr}`);
+    assert.notEqual(r.parsed.reason, "port_conflict", "matching brain must NOT conflict");
+    assert.notEqual(r.parsed.refused, true, "matching brain must not be refused");
+    assert.equal(r.status, 0, `expected success exit 0, got ${r.status}; ${r.stderr}`);
+    // The op DID reach the (matching) server.
+    const sawRemove = received.some((m) => m.action === "remove");
+    assert.equal(sawRemove, true, "matching-brain op should have been routed to the server");
   } finally {
     await new Promise((r) => srv.close(r));
   }


### PR DESCRIPTION
## Summary

Round-2 audit fix. Prior release reconciled `brain_id` only for `--status` / `--stop`; **data operations** (search / index / reindex / remove / forget / query) still routed by **port alone**. On a shared or recycled port, a destructive op could silently hit the **WRONG brain**.

`ensureServer()` now reconciles the responding server's `brain_id` against the expected brain and **fails closed** (`port_conflict`, exit 1) on mismatch — mutations refuse rather than operate on the wrong brain. Read ops also fail closed.

Also de-flaked `server.test.mjs`: the fixed-port bind-or-fail race is replaced with an ephemeral port + retry + health poll.

## Changes

- `server/bin/wicked-brain-call.mjs` — data-path `brain_id` reconciliation guard in `ensureServer()`; fail-closed on mismatch.
- `server/test/wicked-brain-call.test.mjs` — coverage for data-path refuse/allow (remove, index, search refuse on mismatch; matching brain passes through).
- `server/test/server.test.mjs` — de-flake (ephemeral port + retry + health poll).
- Version bump to **0.15.4** across `package.json`, `package-lock.json`, `server/package.json`, `server/package-lock.json` (keeps `npm ci` valid; no release-catchup PR needed).

## Verification

verified: npm test green — `cd server && node --test` → **413 pass / 0 fail**. Includes the new data-path reconciliation tests (mutating + read ops refuse on mismatched brain; matching brain passes through) and the de-flaked server test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)