### PR TITLE
docs: correct synonyms SKILL accuracy (v0.16.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "description": "Digital brain as skills for AI coding CLIs — no vector DB, no embeddings, no infrastructure",
   "keywords": [

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain-server",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "description": "SQLite FTS5 search server for wicked-brain digital knowledge bases",
   "keywords": [

--- a/skills/wicked-brain-synonyms/SKILL.md
+++ b/skills/wicked-brain-synonyms/SKILL.md
@@ -43,8 +43,10 @@ Format:
 ```
 
 Keys are the short/common form. Values are expansions to try when the key
-appears in a search query. The search skill reads this file before executing
-queries and automatically expands sparse results using these mappings.
+appears in a search query. The default search path does NOT read this file —
+`wicked-brain:search` only loads it as a fallback when a direct search returns
+sparse results (0–2 matches), then re-runs the query with matching synonym
+values OR'd in and merges the results.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Doc-only fix to `skills/wicked-brain-synonyms/SKILL.md`. The skill previously claimed the
search skill reads the synonym map **before executing queries** and **expands sparse results**
automatically. That is inaccurate.

Corrected to reflect actual behavior: the default `wicked-brain:search` path does **not** read
the synonym file. Synonyms are applied only as a **fallback** when a direct search returns
sparse results (0–2 matches) — at which point the query is re-run with matching synonym values
OR'd in and the results merged. This matches the slimmed search skill.

## Version

Patch bump `0.16.0 → 0.16.1` (doc-only). Version fields kept in sync across:
- `package.json`
- `package-lock.json` (root + `packages[""]`)
- `server/package.json`
- `server/package-lock.json`

## Tests

`cd server && npm test` (node --test): **414 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)