### PR TITLE
feat: add extraction-method (method:) to chunk + memory frontmatter

### DIFF
--- a/server/test/method-field.test.mjs
+++ b/server/test/method-field.test.mjs
@@ -1,0 +1,166 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseFrontmatterBlock, parseFrontmatter } from "../lib/frontmatter.mjs";
+import { SqliteSearch } from "../lib/sqlite-search.mjs";
+
+// Cross-pollination R1 (Factory B1 / G4): the `method:` frontmatter field
+// records the EXTRACTION METHOD (provenance — "how do we know this") that
+// produced a chunk or memory. It is distinct from `source_type` (file format).
+//
+// These tests pin the field's contract end-to-end. `method` is plain
+// frontmatter: the documents table stores the raw frontmatter blob, so the
+// field rides through index() -> getDocument() verbatim with NO schema
+// migration. The skills (ingest/memory) are the authoring instructions; this
+// test proves the storage + parse path the skills depend on actually carries
+// the field, and that it stays OPTIONAL so pre-existing content is still valid.
+
+function makeDb() {
+  return new SqliteSearch(":memory:", "test-brain");
+}
+
+// --- Parse layer (what wicked-brain:lint reads when validating frontmatter) ---
+
+test("method: parsed as a scalar string from a chunk frontmatter block", () => {
+  const d = parseFrontmatterBlock(
+    [
+      "source: notes.md",
+      "source_type: md",
+      "chunk_id: notes/chunk-001",
+      "method: deterministic-parse",
+      "confidence: 0.7",
+    ].join("\n"),
+  );
+  assert.equal(d.method, "deterministic-parse");
+  // method must NOT collide with source_type — they answer different questions
+  // (provenance vs file format).
+  assert.equal(d.source_type, "md");
+  assert.notEqual(d.method, d.source_type);
+});
+
+test("method: each controlled chunk/memory value round-trips through the parser", () => {
+  for (const value of [
+    "deterministic-parse",
+    "llm-vision",
+    "llm-synthesis",
+    "manual",
+    "session-capture",
+  ]) {
+    const { data } = parseFrontmatter(`---\nmethod: ${value}\n---\n\nbody`);
+    assert.equal(data.method, value, `method should parse as "${value}"`);
+  }
+});
+
+// --- Storage layer (index -> getDocument), no migration required ---
+
+test("ingest: a chunk's method survives index() -> getDocument() in raw frontmatter", () => {
+  const db = makeDb();
+  try {
+    const content = [
+      "---",
+      "source: design-doc.md",
+      "source_type: md",
+      "chunk_id: design-doc/chunk-001",
+      "method: deterministic-parse",
+      "confidence: 0.7",
+      'indexed_at: "2026-06-17T00:00:00Z"',
+      "---",
+      "",
+      "The auth service uses JWT with a 15-minute expiry.",
+    ].join("\n");
+    db.index({ id: "design-doc/chunk-001", path: "chunks/extracted/design-doc/chunk-001.md", content });
+
+    const doc = db.getDocument("design-doc/chunk-001");
+    assert.ok(doc, "document should be retrievable");
+    // The raw frontmatter blob is stored and returned verbatim.
+    assert.match(doc.frontmatter, /method:\s*deterministic-parse/);
+    // ...and re-parses to the controlled value.
+    const fm = parseFrontmatterBlock(doc.frontmatter);
+    assert.equal(fm.method, "deterministic-parse");
+  } finally {
+    db.close();
+  }
+});
+
+test("memory: a memory's method survives index() -> getDocument() in raw frontmatter", () => {
+  const db = makeDb();
+  try {
+    const content = [
+      "---",
+      "type: decision",
+      "tier: semantic",
+      "method: session-capture",
+      "confidence: 0.5",
+      "importance: 7",
+      "ttl_days: null",
+      'indexed_at: "2026-06-17T00:00:00Z"',
+      "---",
+      "",
+      "Decided to store refresh tokens in HttpOnly cookies.",
+    ].join("\n");
+    db.index({ id: "memory/refresh-token-decision", path: "memory/refresh-token-decision.md", content });
+
+    const doc = db.getDocument("memory/refresh-token-decision");
+    assert.ok(doc, "memory should be retrievable");
+    assert.match(doc.frontmatter, /method:\s*session-capture/);
+    const fm = parseFrontmatterBlock(doc.frontmatter);
+    assert.equal(fm.method, "session-capture");
+  } finally {
+    db.close();
+  }
+});
+
+// --- Backward compatibility: method is OPTIONAL ---
+
+test("method is optional: a chunk WITHOUT method still indexes and is retrievable", () => {
+  const db = makeDb();
+  try {
+    const content = [
+      "---",
+      "source: legacy.md",
+      "source_type: md",
+      "chunk_id: legacy/chunk-001",
+      "confidence: 0.7",
+      'indexed_at: "2026-06-17T00:00:00Z"',
+      "---",
+      "",
+      "Pre-existing chunk authored before the method field existed.",
+    ].join("\n");
+    db.index({ id: "legacy/chunk-001", path: "chunks/extracted/legacy/chunk-001.md", content });
+
+    const doc = db.getDocument("legacy/chunk-001");
+    assert.ok(doc, "legacy document must still be retrievable");
+    assert.ok(doc.content.includes("Pre-existing chunk"));
+    // No method present — lint treats this as `method: unknown` (info-only),
+    // it must NOT block indexing or invalidate the document.
+    const fm = parseFrontmatterBlock(doc.frontmatter);
+    assert.equal(fm.method ?? null, null, "absent method parses as missing, not an error");
+  } finally {
+    db.close();
+  }
+});
+
+// --- The lint "no source => assumption" provenance check (C3), as a pure
+//     predicate over parsed frontmatter, so the rule is unit-tested even though
+//     the lint skill itself is markdown instructions. ---
+
+test("lint predicate: unsourced chunk with a non-inferred method is flagged", () => {
+  // Mirrors the rule documented in wicked-brain:lint: a chunk with no
+  // source/source_path whose method is not in {llm-synthesis, unknown} is an
+  // unsourced fact that should be flagged.
+  const INFERRED = new Set(["llm-synthesis", "unknown"]);
+  const isUnsourcedFact = (fm) => {
+    const hasSource = Boolean(fm.source || fm.source_path);
+    const method = fm.method ?? "unknown";
+    return !hasSource && !INFERRED.has(method);
+  };
+
+  // unsourced + deterministic-parse => flagged
+  assert.equal(isUnsourcedFact({ method: "deterministic-parse" }), true);
+  // unsourced + llm-synthesis => NOT flagged (inference is allowed to be sourceless)
+  assert.equal(isUnsourcedFact({ method: "llm-synthesis" }), false);
+  // unsourced + no method (=> unknown) => NOT flagged as "unsourced fact"
+  // (it is caught by the separate missing-method info check instead)
+  assert.equal(isUnsourcedFact({}), false);
+  // sourced + deterministic-parse => NOT flagged
+  assert.equal(isUnsourcedFact({ source: "doc.md", method: "deterministic-parse" }), false);
+});

--- a/skills/wicked-brain-ingest/SKILL.md
+++ b/skills/wicked-brain-ingest/SKILL.md
@@ -115,12 +115,30 @@ entities:
   people: [{people/roles}]
   programs: [{programs/initiatives}]
   metrics: ["{metric}: {value}"]
+method: {extraction method — see "Extraction method" below}
 confidence: {0.7 for text, 0.85 for vision}
 indexed_at: {current ISO timestamp}
 narrative_theme: {the "so what" in 8 words or fewer}
 ---
 
 {Extracted content in markdown format}
+
+## Extraction method
+
+The `method:` field records *how* the chunk's content was obtained — the
+provenance answer to "how do we know this?" It is distinct from `source_type`
+(which is the file format, e.g. `pdf`/`md`/`js`). Set it deterministically
+from the path you are already taking:
+
+- `deterministic-parse` — the TEXT path above (Read + split, no model judgement).
+- `llm-vision` — the BINARY path above (content extracted by the model viewing
+  the document/image).
+
+Use one of the controlled values: `deterministic-parse`, `llm-vision`,
+`llm-synthesis` (model-generated/inferred content), or `manual` (hand-authored).
+The value is plain frontmatter — it is stored and returned verbatim by the
+server with no schema migration. If omitted, downstream lint treats the chunk
+as `method: unknown`; prefer to set it explicitly.
 
 ## Tag Expansion
 
@@ -334,6 +352,10 @@ async function ingestFile(filePath) {
       "  - text",
       "contains:",
       ...keywords.map(k => `  - ${k}`),
+      // method = HOW this chunk was obtained (provenance), distinct from
+      // source_type (file format). The batch path is a deterministic
+      // Read + split with no model judgement.
+      `method: deterministic-parse`,
       `confidence: 0.7`,
       `indexed_at: "${ts}"`,
       "---",

--- a/skills/wicked-brain-lint/SKILL.md
+++ b/skills/wicked-brain-lint/SKILL.md
@@ -82,6 +82,21 @@ For each wiki article with source_hashes in frontmatter:
 ### Missing frontmatter
 Check each chunk has required frontmatter fields (source, chunk_id, confidence, indexed_at).
 
+Also check the **provenance** field `method` (how the chunk/memory was obtained:
+`deterministic-parse`, `llm-vision`, `llm-synthesis`, `manual`, or
+`session-capture` for memories). `method` is **optional** — it was added after
+some content was written, so a chunk/memory without it is still valid. When it
+is missing, auto-fix by stamping `method: unknown` and report the fix as `info`
+severity, type `missing_field` (do NOT raise it to a warning/error — that would
+invalidate pre-existing content). Surfacing `method: unknown` lets a reviewer
+distinguish facts with known provenance from those whose origin was never
+recorded.
+
+Lightweight provenance check (the "no source ⇒ assumption" rule): if a chunk has
+no `source`/`source_path` and its `method` is not one of the inferred kinds
+(`llm-synthesis`, `unknown`), flag it `info`, type `missing_field`:
+`unsourced fact with method "{method}" — add a source or set method to llm-synthesis`.
+
 ### Tag synonym candidates
 
 Call the server to get all tag frequencies:

--- a/skills/wicked-brain-memory/SKILL.md
+++ b/skills/wicked-brain-memory/SKILL.md
@@ -100,6 +100,7 @@ Write to `{brain_path}/memory/{safe_name}.md`:
 ---
 type: {detected or provided type}
 tier: {resolved tier from Step 2b}
+method: {extraction method — see "Extraction method" below}
 confidence: 0.5
 importance: {from type defaults or override}
 ttl_days: {from type defaults or override, null if permanent}
@@ -117,6 +118,21 @@ indexed_at: "{ISO 8601 timestamp}"
 {memory content}
 ```
 
+#### Extraction method
+
+The `method:` field records *how* the memory was obtained — the provenance
+answer to "how do we know this?", mirroring the `method:` field on ingested
+chunks. Set it from how the memory came to be:
+
+- `session-capture` — captured live from the current session (the default for
+  "remember this" during work).
+- `manual` — explicitly stated by the user ("we decided X", interview-style).
+- `llm-synthesis` — inferred/derived by the agent rather than directly observed.
+
+Default to `session-capture` when unsure. The value is plain frontmatter,
+stored and returned verbatim by the server (no schema migration). If omitted,
+lint treats the memory as `method: unknown` — prefer to set it explicitly.
+
 #### Tier definitions
 
 - **working**: Active, session-specific context. Expires quickly (hours to days). Use for in-progress decisions, temporary notes, and things only relevant to the current task.
@@ -131,6 +147,7 @@ New memories start at the tier resolved from importance (default `episodic` for 
 ---
 type: decision
 tier: semantic
+method: manual
 confidence: 0.9
 importance: 7
 ttl_days: null


### PR DESCRIPTION
From a cross-pollination review (KB evidence model).

## Changes
- Add a `method:` (extraction-method) field to chunk + memory frontmatter (ingest + memory skills) with a controlled vocabulary; optional/defaulted — **frontmatter-first, no DB migration** (live `.brain.db` is schema v3; frontmatter rides through verbatim). Does not overload `source_type` (file-format).
- One optional advisory lint line.

## Tests
- `npm test` → **420 pass / 0 fail** (was 414; +6 new covering capture + storage round-trip for both chunk & memory)
- `npm run gen:wiki:check` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
