### PR TITLE
docs(skills): align method: controlled vocabulary across ingest/memory/lint (LOW-1)

### DIFF
--- a/skills/wicked-brain-ingest/SKILL.md
+++ b/skills/wicked-brain-ingest/SKILL.md
@@ -134,11 +134,17 @@ from the path you are already taking:
 - `llm-vision` — the BINARY path above (content extracted by the model viewing
   the document/image).
 
-Use one of the controlled values: `deterministic-parse`, `llm-vision`,
-`llm-synthesis` (model-generated/inferred content), or `manual` (hand-authored).
-The value is plain frontmatter — it is stored and returned verbatim by the
-server with no schema migration. If omitted, downstream lint treats the chunk
-as `method: unknown`; prefer to set it explicitly.
+Use one of the shared controlled values (the same vocabulary across
+`wicked-brain:ingest`, `wicked-brain:memory`, and `wicked-brain:lint`):
+`deterministic-parse`, `llm-vision`, `llm-synthesis`, `session-capture`,
+`manual`, `unknown`. For ingested chunks you will almost always use
+`deterministic-parse` (text) or `llm-vision` (binary); `llm-synthesis` covers
+model-generated/inferred content and `manual` covers hand-authored content.
+`session-capture` applies to memories (see `wicked-brain:memory`), and `unknown`
+is the lint-applied fallback for content written before this field existed. The
+value is plain frontmatter — it is stored and returned verbatim by the server
+with no schema migration. If omitted, downstream lint stamps the chunk as
+`method: unknown`; prefer to set it explicitly.
 
 ## Tag Expansion
 

--- a/skills/wicked-brain-lint/SKILL.md
+++ b/skills/wicked-brain-lint/SKILL.md
@@ -82,15 +82,18 @@ For each wiki article with source_hashes in frontmatter:
 ### Missing frontmatter
 Check each chunk has required frontmatter fields (source, chunk_id, confidence, indexed_at).
 
-Also check the **provenance** field `method` (how the chunk/memory was obtained:
-`deterministic-parse`, `llm-vision`, `llm-synthesis`, `manual`, or
-`session-capture` for memories). `method` is **optional** — it was added after
-some content was written, so a chunk/memory without it is still valid. When it
-is missing, auto-fix by stamping `method: unknown` and report the fix as `info`
-severity, type `missing_field` (do NOT raise it to a warning/error — that would
-invalidate pre-existing content). Surfacing `method: unknown` lets a reviewer
-distinguish facts with known provenance from those whose origin was never
-recorded.
+Also check the **provenance** field `method` (how the chunk/memory was
+obtained). The shared controlled vocabulary — the same set documented by
+`wicked-brain:ingest` and `wicked-brain:memory` — is: `deterministic-parse`,
+`llm-vision`, `llm-synthesis`, `session-capture`, `manual`, `unknown`. In
+practice `deterministic-parse`/`llm-vision` come from ingested chunks,
+`session-capture` from memories, and `llm-synthesis`/`manual` from either.
+`method` is **optional** — it was added after some content was written, so a
+chunk/memory without it is still valid. When it is missing, auto-fix by
+stamping `method: unknown` and report the fix as `info` severity, type
+`missing_field` (do NOT raise it to a warning/error — that would invalidate
+pre-existing content). Surfacing `method: unknown` lets a reviewer distinguish
+facts with known provenance from those whose origin was never recorded.
 
 Lightweight provenance check (the "no source ⇒ assumption" rule): if a chunk has
 no `source`/`source_path` and its `method` is not one of the inferred kinds

--- a/skills/wicked-brain-memory/SKILL.md
+++ b/skills/wicked-brain-memory/SKILL.md
@@ -129,9 +129,17 @@ chunks. Set it from how the memory came to be:
 - `manual` — explicitly stated by the user ("we decided X", interview-style).
 - `llm-synthesis` — inferred/derived by the agent rather than directly observed.
 
+These three are the values you will use for memories. They are drawn from the
+shared controlled vocabulary used across `wicked-brain:ingest`,
+`wicked-brain:memory`, and `wicked-brain:lint`: `deterministic-parse`,
+`llm-vision`, `llm-synthesis`, `session-capture`, `manual`, `unknown`. The
+remaining values (`deterministic-parse`, `llm-vision`) describe ingested
+chunks rather than memories, and `unknown` is the lint-applied fallback for
+content written before this field existed.
+
 Default to `session-capture` when unsure. The value is plain frontmatter,
 stored and returned verbatim by the server (no schema migration). If omitted,
-lint treats the memory as `method: unknown` — prefer to set it explicitly.
+lint stamps the memory as `method: unknown` — prefer to set it explicitly.
 
 #### Tier definitions
 


### PR DESCRIPTION
## What

Code-review nit **LOW-1**: the `method:` extraction-method controlled vocabulary (added in v0.17.0) was documented **inconsistently** across the three skills that reference it:

- `wicked-brain-ingest` listed `deterministic-parse`, `llm-vision`, `llm-synthesis`, `manual` — **omitted** `session-capture`.
- `wicked-brain-memory` listed `session-capture`, `manual`, `llm-synthesis` — **omitted** `deterministic-parse`, `llm-vision`.
- `wicked-brain-lint` had the fullest set but none of the three named `unknown` (the lint-applied fallback) as an explicit member of the vocabulary.

## Change

Aligned all three skills on a single **canonical set** taken from the union:

`deterministic-parse`, `llm-vision`, `llm-synthesis`, `session-capture`, `manual`, `unknown`

Each skill now lists the identical six-value set and labels it the shared vocabulary, while keeping its per-surface guidance on which values are typical (parse/vision for ingested chunks, session-capture for memories, llm-synthesis/manual for either, unknown as the lint fallback).

Docs / skill-frontmatter only — **no schema change, no code change**.

## Tests

- `npm test` → **420 pass, 0 fail**
- `cd server && npm run gen:wiki:check` → **"Wiki generation is current."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)