### PR TITLE
fix(memory): synchronously index a stored memory so same-turn recall can't miss it (#40)

### DIFF
--- a/server/test/memory-skill-index-step.test.mjs
+++ b/server/test/memory-skill-index-step.test.mjs
@@ -20,17 +20,17 @@ const SKILL = path.join(
 test("memory skill invokes a synchronous index in the store flow", async () => {
   const md = await fs.readFile(SKILL, "utf8");
 
-  const idxCall = md.indexOf("wicked-brain-call index");
-  assert.ok(
-    idxCall >= 0,
-    "store flow must call `wicked-brain-call index` (synchronous FTS upsert), not rely on the watcher",
-  );
-
+  // Bound the search to the store flow (after the write step) so an `index`
+  // mention elsewhere (intro/config) can't satisfy this guard as a false positive.
+  const writeStep = md.indexOf("### Step 5: Write memory file");
   const logStep = md.indexOf("Log the store event");
+  assert.ok(writeStep >= 0, "expected the 'Write memory file' step to exist");
   assert.ok(logStep >= 0, "expected the 'Log the store event' step to exist");
+
+  const idxCall = md.indexOf("wicked-brain-call index", writeStep);
   assert.ok(
-    idxCall < logStep,
-    "the synchronous index call must come before the log step, i.e. inside the store flow before recall",
+    idxCall >= 0 && idxCall < logStep,
+    "store flow must call `wicked-brain-call index` (synchronous FTS upsert) between the write step and the log step — not rely on the watcher",
   );
 
   assert.ok(

--- a/server/test/memory-skill-index-step.test.mjs
+++ b/server/test/memory-skill-index-step.test.mjs
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for the store→recall race (issue #40): the memory skill must
+// synchronously `index` a freshly-written memory BEFORE it is considered stored,
+// rather than relying on the async, debounced file watcher. If this structure
+// regresses, a store followed by a same-turn recall can silently miss the memory.
+const SKILL = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "skills",
+  "wicked-brain-memory",
+  "SKILL.md",
+);
+
+test("memory skill invokes a synchronous index in the store flow", async () => {
+  const md = await fs.readFile(SKILL, "utf8");
+
+  const idxCall = md.indexOf("wicked-brain-call index");
+  assert.ok(
+    idxCall >= 0,
+    "store flow must call `wicked-brain-call index` (synchronous FTS upsert), not rely on the watcher",
+  );
+
+  const logStep = md.indexOf("Log the store event");
+  assert.ok(logStep >= 0, "expected the 'Log the store event' step to exist");
+  assert.ok(
+    idxCall < logStep,
+    "the synchronous index call must come before the log step, i.e. inside the store flow before recall",
+  );
+
+  assert.ok(
+    /do\s+\*?\*?not\*?\*?\s+rely on the file watcher alone/i.test(md),
+    "store flow must warn against relying on the async file watcher alone",
+  );
+});

--- a/skills/wicked-brain-memory/SKILL.md
+++ b/skills/wicked-brain-memory/SKILL.md
@@ -180,9 +180,40 @@ indexed_at: "2026-04-07T14:23:01Z"
 Decided to use JWT with a 15-minute expiry for the auth-service API. Refresh tokens stored in HttpOnly cookies with 7-day TTL. Rationale: short access token lifetime limits blast radius if a token is leaked.
 ```
 
-The server's file watcher will auto-index this file.
+### Step 6: Index the memory synchronously
 
-### Step 6: Log the store event
+Immediately after writing the file, index it through the server so the memory
+is recallable in the *same* step. Do **not** rely on the file watcher alone —
+it is asynchronous and debounced, so a `store` followed by a `recall` in the
+same turn can miss the memory that was just written.
+
+The server's `index` action is a synchronous single-document upsert. It
+auto-extracts frontmatter from the content, so pass the full file body
+(frontmatter included) exactly as written in Step 5:
+
+```bash
+npx wicked-brain-call index '{"id":"memory/{safe_name}.md","path":"memory/{safe_name}.md","content":"{file_content}"}'
+```
+
+`content` is a JSON **string**, so the body must be JSON-encoded — newlines
+escaped as `\n` and embedded quotes as `\"`. A raw newline makes the payload
+invalid JSON and the call aborts *before* indexing, silently leaving the
+store→recall race in place. Build the payload with a real JSON encoder (not
+string concatenation); for a multi-line body, pipe the already-encoded JSON via
+stdin so the shell doesn't fight the outer quoting (the `\n` escaping *inside*
+the string is still required either way):
+
+```bash
+# $PAYLOAD holds a valid one-line JSON object (content already \n-escaped)
+printf '%s' "$PAYLOAD" | npx wicked-brain-call index -
+```
+
+`index` is idempotent and its `id` matches the file-watcher's id scheme, so
+re-running it upserts the same row — safe even though the watcher will also
+observe the write later. This synchronous call is what makes a freshly-stored
+memory immediately recallable in the same turn.
+
+### Step 7: Log the store event
 
 Append to `{brain_path}/_meta/log.jsonl`:
 
@@ -190,7 +221,7 @@ Append to `{brain_path}/_meta/log.jsonl`:
 {"ts":"{ISO}","op":"memory_store","path":"memory/{safe_name}.md","type":"{type}","tier":"{resolved tier}","author":"agent:memory"}
 ```
 
-### Step 7: Emit bus event
+### Step 8: Emit bus event
 
 ```bash
 npx wicked-bus emit \


### PR DESCRIPTION
Fixes #40 — the memory store→recall race.

## Problem
`store` wrote the file and relied on the async, debounced file watcher to index it; `recall` reads FTS immediately, so a store→recall in the same turn could miss the just-written memory.

## Fix
Add an explicit **synchronous** `wicked-brain-call index` step right after the write (before log/emit/return). The server's `index` action is an idempotent single-doc FTS upsert whose `id` matches the watcher's scheme, so the later watcher pass just upserts the same row.

## Adversarial review follow-ups applied
- Corrected the multi-line JSON guidance — `content` must be `\n`-escaped regardless of inline vs stdin (a raw newline aborts the call *before* indexing, silently re-opening the race).
- Dropped the inert `brain_id` payload field (`db.index` uses the server's own brain id).
- Added a **structural regression test** (`server/test/memory-skill-index-step.test.mjs`) asserting the store flow indexes before the log step and warns against watcher-only reliance.

## Tests
`cd server && node --test` → **421 pass / 0 fail** (adds 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)