### PR TITLE
fix(memory): canonical projectId() slug to end split-brain fragmentation (#56)

### DIFF
--- a/docs/wiki/_generated/actions.json
+++ b/docs/wiki/_generated/actions.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-10",
+  "generated_at": "2026-07-12",
   "source": "server/bin/wicked-brain-server.mjs",
   "canonical_id": "CONTRACT-API",
   "count": 40,

--- a/docs/wiki/_generated/files.json
+++ b/docs/wiki/_generated/files.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-06-10",
+  "generated_at": "2026-07-12",
   "source_roots": [
     "server/lib",
     "server/bin"
   ],
   "canonical_id": "MAP-FILES",
-  "count": 32,
+  "count": 33,
   "files": [
     {
       "path": "server/bin/onboard-wiki.mjs",
@@ -19,7 +19,9 @@
       "path": "server/bin/wicked-brain-call.mjs",
       "purpose": "",
       "exports": [],
-      "imports": []
+      "imports": [
+        "../lib/project-id.mjs"
+      ]
     },
     {
       "path": "server/bin/wicked-brain-server.mjs",
@@ -316,6 +318,17 @@
         "./mode-config.mjs",
         "./stamp-pointer.mjs"
       ]
+    },
+    {
+      "path": "server/lib/project-id.mjs",
+      "purpose": "Canonical project-id slug + per-project brain resolution.",
+      "exports": [
+        "baseName",
+        "projectId",
+        "resolvePerProjectBrain",
+        "slugifyId"
+      ],
+      "imports": []
     },
     {
       "path": "server/lib/sqlite-search.mjs",

--- a/docs/wiki/_generated/schema.json
+++ b/docs/wiki/_generated/schema.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-10",
+  "generated_at": "2026-07-12",
   "source": "server/lib/sqlite-search.mjs",
   "canonical_id": "CONTRACT-SCHEMA",
   "head_version": 6,

--- a/docs/wiki/contract-api.md
+++ b/docs/wiki/contract-api.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [CONTRACT-API]
 references: []
 owner: core
-last_reviewed: 2026-06-10
+last_reviewed: 2026-07-12
 generated: true
 source: server/bin/wicked-brain-server.mjs
 ---

--- a/docs/wiki/contract-schema.md
+++ b/docs/wiki/contract-schema.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [CONTRACT-SCHEMA]
 references: [INV-MIGRATION-REQUIRED]
 owner: core
-last_reviewed: 2026-06-10
+last_reviewed: 2026-07-12
 generated: true
 source: server/lib/sqlite-search.mjs
 ---

--- a/docs/wiki/map-files.md
+++ b/docs/wiki/map-files.md
@@ -3,7 +3,7 @@ status: published
 canonical_for: [MAP-FILES]
 references: []
 owner: core
-last_reviewed: 2026-06-10
+last_reviewed: 2026-07-12
 generated: true
 source_roots: [server/lib, server/bin]
 ---
@@ -17,7 +17,7 @@ Generated walk of `server/lib`, `server/bin`. Do not hand-edit — regenerate wi
 | Path | Purpose | Exports | Local imports |
 |---|---|---|---|
 | `server/bin/onboard-wiki.mjs` | wicked-brain-onboard-wiki | — | `../lib/onboard-wiki.mjs` |
-| `server/bin/wicked-brain-call.mjs` | — | — | — |
+| `server/bin/wicked-brain-call.mjs` | — | — | `../lib/project-id.mjs` |
 | `server/bin/wicked-brain-server.mjs` | Listen on `startPort`, probing upward on EADDRINUSE. Probes using the real server instance so the bind semantics (dual-stack IPv4+IPv6) match the eventual listener — a separate 127.0.0.1 probe would miss an IPv6-only conflict and produce a false "free" result. | — | `../lib/brain-walker.mjs`, `../lib/bus.mjs`, `../lib/codegraph-actions.mjs`, `../lib/file-watcher.mjs`, `../lib/lsp-client.mjs`, `../lib/memory-subscriber.mjs`, `../lib/onboard-wiki.mjs`, `../lib/sqlite-search.mjs`, `../lib/viewer-page.mjs` |
 | `server/lib/brain-walker.mjs` | Walk a brain path and surface every authored `.md` file under the content subdirectories (chunks/, wiki/, memory/). Deliberately excludes `_meta/`, `raw/`, `.brain.db`, and any dotfile/dotdir. Paths returned are relative to the brain path and use forward slashes per INV-PATHS-FORWARD. | `purgeBrainContent`, `walkBrainContent` | — |
 | `server/lib/bus.mjs` | wicked-bus integration for wicked-brain-server. | `busAvailable`, `dropBusDeadLetter`, `emitEvent`, `getBusDb`, `isBusAvailable`, `listBusDeadLetters`, `replayBusDeadLetter`, `waitForBus` | — |
@@ -44,6 +44,7 @@ Generated walk of `server/lib`, `server/bin`. Do not hand-edit — regenerate wi
 | `server/lib/memory-subscriber.mjs` | Auto-memorize subscriber: bridges wicked-bus fact events into brain memories. | `fastForwardStaleCursor`, `renderMemoryFile`, `startMemorySubscriber` | `./bus.mjs`, `./memory-promoter.mjs` |
 | `server/lib/mode-config.mjs` | Validate a mode.json body. Returns { ok, errors } — does not throw. Kept in lockstep with mode.schema.json. The schema is the canonical documentation; this is the runtime enforcement. | `MODE_FILE_PATH`, `diffMode`, `readModeFile`, `validateMode`, `writeModeFile` | — |
 | `server/lib/onboard-wiki.mjs` | Onboard-wiki orchestrator. | `formatOnboardResult`, `runOnboardWiki` | `./detect-mode.mjs`, `./mode-config.mjs`, `./stamp-pointer.mjs` |
+| `server/lib/project-id.mjs` | Canonical project-id slug + per-project brain resolution. | `baseName`, `projectId`, `resolvePerProjectBrain`, `slugifyId` | — |
 | `server/lib/sqlite-search.mjs` | Parse a source_hashes entry of the form "{chunk_path}: {hash}". Returns null if the shape doesn't match — malformed entries are skipped rather than blocking the whole verify call. | `SqliteSearch`, `deriveSourceType` | `./frontmatter.mjs`, `./wikilinks.mjs` |
 | `server/lib/stamp-pointer.mjs` | CLAUDE.md / AGENTS.md contributor-wiki pointer stamping. | `buildSection`, `stampWikiPointer` | — |
 | `server/lib/viewer-page.mjs` | Read-only HTML viewer for a wicked-brain instance. | `renderViewerHtml` | — |

--- a/server/bin/wicked-brain-call.mjs
+++ b/server/bin/wicked-brain-call.mjs
@@ -109,9 +109,18 @@ function hasBrainIndex(dir) {
 
 // True when `subdir` exists and is non-empty. Best-effort — a missing/unreadable
 // dir counts as empty.
-function dirNotEmpty(subdir) {
+function dirHasContent(subdir) {
   try {
-    return readdirSync(subdir).length > 0;
+    // Ignore the `.gitkeep` placeholders wicked-brain:init writes into an
+    // otherwise-empty brain, and recurse so an empty chunks/{extracted,inferred}
+    // scaffold doesn't read as content — otherwise a FRESH canonical brain would
+    // wrongly count as "populated" and defeat split-brain protection (serving the
+    // empty brain over a populated legacy one → silent data loss). Fix for #56.
+    return readdirSync(subdir, { withFileTypes: true }).some((entry) => {
+      if (entry.name === ".gitkeep") return false;
+      if (entry.isDirectory()) return dirHasContent(join(subdir, entry.name));
+      return true;
+    });
   } catch {
     return false;
   }
@@ -123,9 +132,9 @@ function dirNotEmpty(subdir) {
 // hasIndex alone would wrongly treat it as empty (#56 follow-up).
 function hasBrainContent(dir) {
   return (
-    dirNotEmpty(join(dir, "memory")) ||
-    dirNotEmpty(join(dir, "raw")) ||
-    dirNotEmpty(join(dir, "chunks"))
+    dirHasContent(join(dir, "memory")) ||
+    dirHasContent(join(dir, "raw")) ||
+    dirHasContent(join(dir, "chunks"))
   );
 }
 

--- a/server/bin/wicked-brain-call.mjs
+++ b/server/bin/wicked-brain-call.mjs
@@ -14,12 +14,15 @@ import {
   openSync,
   closeSync,
   statSync,
+  readdirSync,
+  realpathSync,
 } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { homedir } from "node:os";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
+import { projectId, resolvePerProjectBrain } from "../lib/project-id.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const SERVER_BIN = join(__dirname, "wicked-brain-server.mjs");
@@ -81,21 +84,91 @@ function coerce(s) {
 // Mirrors the resolution skills use: explicit flag → env → per-project →
 // legacy flat. Returning the per-project path even when nothing exists yet
 // lets `--start` create the directory cleanly.
+//
+// The per-project slug is CANONICAL (kebab-case via projectId) so the same repo
+// always maps to the same brain dir regardless of which tool resolved it — the
+// fix for the split-brain fragmentation in wicked-brain#56, where the CLI keyed
+// on the raw cwd basename (`command_iq`) while the init skill kebab-cased it
+// (`command-iq`). resolvePerProjectBrain also detects an existing legacy
+// raw-basename store alongside the canonical one and surfaces an actionable
+// warning (via onWarn) instead of silently serving a degraded/empty brain.
 
-function resolveBrainPath(explicit) {
+// True when `dir` is an initialized brain (has meta config or brain.json).
+function isBrainStore(dir) {
+  return (
+    existsSync(join(dir, "_meta", "config.json")) ||
+    existsSync(join(dir, "brain.json"))
+  );
+}
+
+// True when `dir` holds a built SQLite index. Presence of `.brain.db` is the
+// signal that separated the rich store from the degraded one in #56.
+function hasBrainIndex(dir) {
+  return existsSync(join(dir, ".brain.db"));
+}
+
+// True when `subdir` exists and is non-empty. Best-effort — a missing/unreadable
+// dir counts as empty.
+function dirNotEmpty(subdir) {
+  try {
+    return readdirSync(subdir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// True when `dir` holds real on-disk content independent of the built index —
+// any memory note or raw/chunk source file. In a split, a store can be fresh
+// (notes present, `.brain.db` not built yet) yet still hold the user's data;
+// hasIndex alone would wrongly treat it as empty (#56 follow-up).
+function hasBrainContent(dir) {
+  return (
+    dirNotEmpty(join(dir, "memory")) ||
+    dirNotEmpty(join(dir, "raw")) ||
+    dirNotEmpty(join(dir, "chunks"))
+  );
+}
+
+// True when two paths resolve to the SAME underlying directory. On a
+// case-insensitive filesystem (macOS APFS default, Windows) the legacy raw
+// basename and the canonical kebab slug can name one physical dir through two
+// case variants (`MyRepo` vs `myrepo`); realpath collapses both to the true
+// on-disk path so we don't misread a case variant as a split. `.native` returns
+// the OS-canonical casing; fall back to plain realpath where unavailable.
+function sameUnderlyingDir(a, b) {
+  const real = realpathSync.native || realpathSync;
+  try {
+    return real(a) === real(b);
+  } catch {
+    return false;
+  }
+}
+
+function resolveBrainPath(explicit, { onWarn } = {}) {
   if (explicit) return resolve(explicit);
   if (process.env.WICKED_BRAIN_PATH) return resolve(process.env.WICKED_BRAIN_PATH);
-  const cwdBase = basename(process.cwd());
-  const perProject = join(homedir(), ".wicked-brain", "projects", cwdBase);
-  if (
-    existsSync(join(perProject, "_meta", "config.json")) ||
-    existsSync(join(perProject, "brain.json"))
-  ) {
-    return perProject;
-  }
+
+  const projectsRoot = join(homedir(), ".wicked-brain", "projects");
+  const resolved = resolvePerProjectBrain({
+    cwd: process.cwd(),
+    projectsRoot,
+    storeExists: isBrainStore,
+    hasIndex: hasBrainIndex,
+    hasContent: hasBrainContent,
+    sameDir: sameUnderlyingDir,
+    joinPath: join,
+  });
+  if (resolved.warning && typeof onWarn === "function") onWarn(resolved.warning);
+
+  // A per-project store (canonical or legacy) already exists — use it.
+  if (isBrainStore(resolved.path)) return resolved.path;
+
+  // No per-project store yet — honor a legacy flat brain if one is present.
   const flat = join(homedir(), ".wicked-brain");
   if (existsSync(join(flat, "_meta", "config.json"))) return flat;
-  return perProject;
+
+  // Fresh brain: the canonical per-project dir (so new brains are never split).
+  return resolved.path;
 }
 
 function readMetaConfig(brainPath) {
@@ -335,12 +408,14 @@ async function ensureServer(brainPath, opts) {
 
     log(`starting wicked-brain-server (brain=${brainPath} port=${port})`);
     let sourcePath = sourceOverride || meta.source_path;
-    // Per-project brains are keyed on basename(cwd). Configs written before
-    // source_path persistence lack the field — derive it from cwd (only when
-    // the basename convention confirms cwd is the project root) so the server
-    // roots LSP at the project and persists source_path for port-resolution
-    // consumers (wicked-garden hooks match configs by source_path).
-    if (!sourcePath && basename(brainPath) === basename(process.cwd())) {
+    // Per-project brains are keyed on the canonical projectId(cwd). Configs
+    // written before source_path persistence lack the field — derive it from cwd
+    // (only when the canonical slug confirms this brain dir belongs to cwd) so
+    // the server roots LSP at the project and persists source_path for
+    // port-resolution consumers (wicked-garden hooks match configs by
+    // source_path). Compare via projectId so a raw-basename brain dir
+    // (`command_iq`) still matches its canonical cwd (`command-iq`) and vice versa.
+    if (!sourcePath && projectId(brainPath) === projectId(process.cwd())) {
       sourcePath = process.cwd();
     }
     const argv = [SERVER_BIN, "--brain", brainPath, "--port", String(port)];
@@ -598,7 +673,9 @@ Examples:
   }
 
   const log = (msg) => process.stderr.write(`[wicked-brain-call] ${msg}\n`);
-  const brainPath = resolveBrainPath(args.flags.brain);
+  const brainPath = resolveBrainPath(args.flags.brain, {
+    onWarn: (msg) => log(`WARNING: ${msg}`),
+  });
 
   // ---- --status ----
   if (args.flags.status) {

--- a/server/lib/project-id.mjs
+++ b/server/lib/project-id.mjs
@@ -1,0 +1,188 @@
+/**
+ * Canonical project-id slug + per-project brain resolution.
+ *
+ * ONE convention, shared by the call CLI, the server-path resolver, and the
+ * init/status/migrate skills, so a single repo always maps to the same brain
+ * directory. Before this module the call CLI keyed brains on the RAW cwd
+ * basename (underscore preserved) while the init skill kebab-cased the id — so
+ * `command_iq` (path) and `command-iq` (init) diverged and one repo's memory
+ * fragmented across sibling stores (see wicked-brain#56).
+ *
+ * Canonical convention: **kebab-case** — lowercase, non-alphanumerics collapse
+ * to a single hyphen, trimmed. It matches `slugify()` in memory-promoter (used
+ * for memory titles), is the documented/intended id in the init skill, and is
+ * filesystem-safe on macOS, Linux, and Windows. Underscores and spaces fold to
+ * hyphens; `command_iq` → `command-iq`.
+ *
+ * Pure module — no fs, no I/O. `resolvePerProjectBrain` takes fs probes as
+ * callbacks so it stays testable and cross-platform (forward slashes only).
+ *
+ * @module lib/project-id
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Extract the trailing path segment from a cwd or bare name, tolerating both
+ * `/` and `\\` separators so callers can pass `process.cwd()` on any OS.
+ */
+export function baseName(input) {
+  const s = String(input || "").replace(/\\/g, "/").replace(/\/+$/g, "");
+  const idx = s.lastIndexOf("/");
+  return idx === -1 ? s : s.slice(idx + 1);
+}
+
+/**
+ * Kebab-case a bare name into a canonical, filesystem-safe slug.
+ * Unicode is folded toward ASCII via NFKD (é → e); any name that folds away to
+ * nothing (e.g. all-CJK) falls back to a short, deterministic hash of the
+ * original so two distinct names never collapse to the same empty slug.
+ */
+// Combining diacritical marks (U+0300–U+036F). NFKD splits `é` into `e` + one
+// of these; dropping them folds the accent away instead of turning it into a
+// stray hyphen. Built via RegExp() so no literal combining chars sit in source.
+const COMBINING_MARKS = new RegExp("[\\u0300-\\u036f]", "g");
+
+export function slugifyId(text) {
+  const raw = String(text || "");
+  const slug = raw
+    .normalize("NFKD")
+    .replace(COMBINING_MARKS, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (slug) return slug;
+  // Nothing survived slugification — keep it deterministic and collision-free.
+  return "brain-" + createHash("sha1").update(raw).digest("hex").slice(0, 8);
+}
+
+/**
+ * Canonical project id for a working directory (or bare project name).
+ * `projectId('/Users/me/Projects/command_iq')` → `'command-iq'`.
+ */
+export function projectId(input) {
+  return slugifyId(baseName(input));
+}
+
+/**
+ * Resolve the per-project brain directory for a cwd, canonicalizing the slug and
+ * detecting legacy raw-basename fragmentation. Pure: the caller supplies the fs
+ * probes so this is testable without touching disk and stays cross-platform.
+ *
+ * Least-surprising, no-data-loss policy (wicked-brain#56):
+ *  - Fresh repo (no store yet)     → canonical dir. New brains are always canonical.
+ *  - Only the canonical store      → canonical dir.
+ *  - Only a legacy raw-basename    → serve the legacy store transparently (the
+ *    store exists              user's existing brain keeps working) + warn to migrate.
+ *  - BOTH exist (a true split)     → prefer the POPULATED store; never silently
+ *                                    serve an empty brain while a populated
+ *                                    sibling holds the data. Tie-break to
+ *                                    canonical. Always warn with the merge path.
+ *
+ * Case-insensitive filesystems (macOS APFS default, Windows): the legacy raw
+ * basename and the canonical kebab slug can be distinct *strings* that name the
+ * SAME physical directory (e.g. `MyRepo` vs `myrepo`). That is one store, not a
+ * split — `sameDir` lets the caller detect it (realpath/inode compare) so a
+ * case-only variant never reads as a fragmented brain.
+ *
+ * "Populated" is decided by real data, not just a built index: a store counts as
+ * populated if it has a `.brain.db` (`hasIndex`) OR on-disk content such as
+ * `memory/*.md` or raw/chunk files (`hasContent`). So a freshly-created legacy
+ * store whose index hasn't been built yet still wins over an empty canonical.
+ *
+ * @param {object} o
+ * @param {string} o.cwd            working directory (any OS separators)
+ * @param {string} o.projectsRoot   e.g. `~/.wicked-brain/projects`
+ * @param {(dir:string)=>boolean} o.storeExists  true if `dir` is an initialized brain
+ * @param {(dir:string)=>boolean} o.hasIndex     true if `dir` has a built `.brain.db`
+ * @param {(dir:string)=>boolean} [o.hasContent] true if `dir` holds on-disk content
+ *   (memory/*.md, raw/chunks) even without a built index. Defaults to always-false
+ *   (index-only) so callers that don't probe content keep the old behavior.
+ * @param {(a:string,b:string)=>boolean} [o.sameDir] true if two paths refer to the
+ *   SAME underlying directory (case-insensitive FS guard). Defaults to never-same.
+ * @param {(a:string,b:string)=>string} o.joinPath  path join (defaults to `a/b`)
+ * @returns {{ path:string, canonicalId:string, legacyId:string,
+ *             canonicalDir:string, legacyDir:string, collision:boolean,
+ *             warning:(string|null) }}
+ */
+export function resolvePerProjectBrain({
+  cwd,
+  projectsRoot,
+  storeExists,
+  hasIndex,
+  hasContent = () => false,
+  sameDir = () => false,
+  joinPath = (a, b) => `${a}/${b}`,
+}) {
+  const canonicalId = projectId(cwd);
+  const legacyId = baseName(cwd);
+  const canonicalDir = joinPath(projectsRoot, canonicalId);
+  const legacyDir = joinPath(projectsRoot, legacyId);
+
+  // The legacy raw basename only diverges when it isn't already canonical.
+  const split = !!legacyId && legacyId !== canonicalId;
+  const canonExists = storeExists(canonicalDir);
+  let legacyExists = split && storeExists(legacyDir);
+
+  // Case-insensitive FS guard: when BOTH paths appear to exist, they may in fact
+  // be the same physical directory reached through two case/format variants of
+  // the name. If so it's a single store — collapse to the canonical path instead
+  // of reporting a false split. Only probe when both look present (avoids
+  // realpath-on-missing throws) and never against a genuinely distinct dir
+  // (e.g. `command_iq` vs `command-iq`, which realpath to different inodes).
+  if (legacyExists && canonExists && sameDir(canonicalDir, legacyDir)) {
+    legacyExists = false;
+  }
+
+  const base = { canonicalId, legacyId, canonicalDir, legacyDir };
+
+  // No divergence, or the legacy dir isn't an initialized brain: canonical path.
+  if (!legacyExists) {
+    return { ...base, path: canonicalDir, collision: false, warning: null };
+  }
+
+  const mergeCmd =
+    `wicked-brain:migrate (merge legacy "${legacyId}" into canonical "${canonicalId}")`;
+
+  if (!canonExists) {
+    // Only the legacy raw-basename store is initialized. Serve it so the user's
+    // existing brain keeps working, but tell them to move it to the canonical id.
+    return {
+      ...base,
+      path: legacyDir,
+      collision: false,
+      warning:
+        `brain for this repo lives under the legacy id "${legacyId}"; the ` +
+        `canonical id is "${canonicalId}". Serving the legacy store. ` +
+        `Run ${mergeCmd} to reconcile.`,
+    };
+  }
+
+  // Both stores exist — a true split brain. Prefer whichever actually holds
+  // data so we never serve an empty/degraded brain while a populated sibling
+  // sits unused. "Populated" = a built index OR on-disk content (memory/*.md,
+  // raw/chunks): a fresh store with notes but no `.brain.db` yet still counts,
+  // so we don't silently serve the empty one over one that has real content.
+  // Tie-break to the canonical store only when BOTH are genuinely empty.
+  const canonPopulated = hasIndex(canonicalDir) || hasContent(canonicalDir);
+  const legacyPopulated = hasIndex(legacyDir) || hasContent(legacyDir);
+  const serveLegacy = !canonPopulated && legacyPopulated;
+  const path = serveLegacy ? legacyDir : canonicalDir;
+
+  // Describe WHY the legacy store won, accurately for either signal.
+  const legacyReason = hasIndex(legacyDir) ? "it has an index" : "it holds content";
+
+  return {
+    ...base,
+    path,
+    collision: true,
+    warning:
+      `split brain: both canonical "${canonicalId}" and legacy "${legacyId}" ` +
+      `exist for this repo. Serving the ` +
+      (serveLegacy
+        ? `legacy store (${legacyReason}; canonical is empty). `
+        : `canonical store. `) +
+      `Run ${mergeCmd} to merge them into one.`,
+  };
+}

--- a/server/test/project-id.test.mjs
+++ b/server/test/project-id.test.mjs
@@ -1,0 +1,262 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  projectId,
+  slugifyId,
+  baseName,
+  resolvePerProjectBrain,
+} from "../lib/project-id.mjs";
+
+// ---- projectId / slugifyId: the canonical slug convention (kebab-case) ----
+
+test("underscores fold to hyphens (the #56 command_iq split)", () => {
+  assert.equal(projectId("/Users/me/Projects/command_iq"), "command-iq");
+  // The two divergent ids collapse to the SAME canonical slug.
+  assert.equal(projectId("command_iq"), projectId("command-iq"));
+});
+
+test("spaces fold to a single hyphen and collapse runs", () => {
+  assert.equal(slugifyId("My Cool Project"), "my-cool-project");
+  assert.equal(slugifyId("a   b"), "a-b");
+  assert.equal(slugifyId("a___b"), "a-b");
+  assert.equal(slugifyId("mixed _ - space"), "mixed-space");
+});
+
+test("case is folded to lowercase", () => {
+  assert.equal(slugifyId("WickedBrain"), "wickedbrain");
+  assert.equal(slugifyId("Command_IQ"), "command-iq");
+  assert.equal(projectId("/x/y/Wicked-Estate"), "wicked-estate");
+});
+
+test("leading/trailing separators are trimmed", () => {
+  assert.equal(slugifyId("_foo_"), "foo");
+  assert.equal(slugifyId("--foo--"), "foo");
+  assert.equal(slugifyId(".hidden."), "hidden");
+});
+
+test("unicode folds toward ASCII via NFKD", () => {
+  assert.equal(slugifyId("café"), "cafe");
+  assert.equal(slugifyId("naïve-project"), "naive-project");
+  assert.equal(slugifyId("Zürich_Repo"), "zurich-repo");
+  // Compatibility ligatures decompose under NFKD (ﬁ → fi).
+  assert.equal(slugifyId("ﬁnance"), "finance");
+});
+
+test("names that fold away to nothing get a deterministic, collision-free slug", () => {
+  const a = slugifyId("日本語");
+  const b = slugifyId("한국어");
+  assert.ok(a.length > 0, "empty-fold name must still yield a non-empty slug");
+  assert.ok(a.startsWith("brain-"));
+  assert.equal(a, slugifyId("日本語"), "must be deterministic");
+  assert.notEqual(a, b, "distinct non-latin names must not collapse together");
+});
+
+test("empty / nullish input is handled", () => {
+  assert.equal(projectId(""), slugifyId(""));
+  assert.equal(projectId(undefined), slugifyId(""));
+  assert.ok(slugifyId("").startsWith("brain-"));
+});
+
+// ---- baseName: cross-platform trailing-segment extraction ----
+
+test("baseName handles both separators and trailing slashes", () => {
+  assert.equal(baseName("/Users/me/Projects/command_iq"), "command_iq");
+  assert.equal(baseName("C:\\Users\\me\\command_iq"), "command_iq");
+  assert.equal(baseName("/Users/me/proj/"), "proj");
+  assert.equal(baseName("bare-name"), "bare-name");
+});
+
+// ---- path-resolution and the init skill agree on the slug ----
+// The init SKILL.md documents: "Lowercase the result and replace
+// non-alphanumeric characters with hyphens." Reproduce that rule independently
+// and assert projectId() produces the identical slug, so the resolver and the
+// skill can never drift again (the root cause of #56).
+
+function skillDocumentedSlug(cwdBasename) {
+  return cwdBasename
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+test("projectId agrees with the init skill's documented kebab rule", () => {
+  for (const name of [
+    "command_iq",
+    "wicked-brain",
+    "My_Repo",
+    "some.dotted.name",
+    "trailing_",
+    "UPPER_CASE_THING",
+  ]) {
+    assert.equal(
+      projectId("/somewhere/" + name),
+      skillDocumentedSlug(name),
+      `projectId disagreed with the skill rule for "${name}"`,
+    );
+  }
+});
+
+// ---- resolvePerProjectBrain: fragmentation-safe resolution ----
+
+const ROOT = "/home/u/.wicked-brain/projects";
+const join = (a, b) => `${a}/${b}`;
+
+function resolveWith(cwd, stores, indexed = []) {
+  const storeSet = new Set(stores.map((s) => join(ROOT, s)));
+  const indexSet = new Set(indexed.map((s) => join(ROOT, s)));
+  return resolvePerProjectBrain({
+    cwd,
+    projectsRoot: ROOT,
+    storeExists: (dir) => storeSet.has(dir),
+    hasIndex: (dir) => indexSet.has(dir),
+    joinPath: join,
+  });
+}
+
+test("fresh repo → canonical dir, no warning", () => {
+  const r = resolveWith("/p/command_iq", []);
+  assert.equal(r.path, join(ROOT, "command-iq"));
+  assert.equal(r.collision, false);
+  assert.equal(r.warning, null);
+});
+
+test("only canonical store exists → canonical dir, no warning", () => {
+  const r = resolveWith("/p/command_iq", ["command-iq"], ["command-iq"]);
+  assert.equal(r.path, join(ROOT, "command-iq"));
+  assert.equal(r.warning, null);
+});
+
+test("only legacy raw-basename store exists → serve legacy + warn to migrate", () => {
+  const r = resolveWith("/p/command_iq", ["command_iq"], ["command_iq"]);
+  assert.equal(r.path, join(ROOT, "command_iq"), "must not strand the existing brain");
+  assert.equal(r.collision, false);
+  assert.match(r.warning, /legacy id "command_iq"/);
+  assert.match(r.warning, /canonical id is "command-iq"/);
+});
+
+test("SPLIT: both exist, canonical degraded (no index), legacy has index → serve legacy + warn (the #56 case)", () => {
+  const r = resolveWith(
+    "/p/command_iq",
+    ["command-iq", "command_iq"], // both initialized
+    ["command_iq"],               // only the legacy store has a .brain.db
+  );
+  assert.equal(r.path, join(ROOT, "command_iq"), "must serve the populated store, not the empty one");
+  assert.equal(r.collision, true);
+  assert.match(r.warning, /split brain/);
+  assert.match(r.warning, /it has an index; canonical is empty/);
+});
+
+test("SPLIT: both exist and canonical is populated → prefer canonical", () => {
+  const r = resolveWith(
+    "/p/command_iq",
+    ["command-iq", "command_iq"],
+    ["command-iq", "command_iq"], // both populated → tie-break to canonical
+  );
+  assert.equal(r.path, join(ROOT, "command-iq"));
+  assert.equal(r.collision, true);
+  assert.match(r.warning, /split brain/);
+});
+
+test("no divergence when the basename is already canonical (no false collision)", () => {
+  const r = resolveWith("/p/wicked-brain", ["wicked-brain"], ["wicked-brain"]);
+  assert.equal(r.legacyId, r.canonicalId);
+  assert.equal(r.collision, false);
+  assert.equal(r.warning, null);
+  assert.equal(r.path, join(ROOT, "wicked-brain"));
+});
+
+// ---- #1: case-insensitive FS must not report a case-only variant as a split ----
+// On macOS APFS / Windows, cwd basename `MyRepo` slugs to canonical `myrepo`, and
+// both `projects/MyRepo` and `projects/myrepo` are the SAME physical dir. The two
+// `storeExists` probes both hit that one dir; without the `sameDir` guard the
+// resolver would see "both stores exist" and fabricate a split. Inject the probes
+// so the test is deterministic on ANY host filesystem.
+
+test("case-only basename variant on a case-insensitive FS is NOT a split (#1 regression guard)", () => {
+  const canonicalDir = join(ROOT, "myrepo");
+  const legacyDir = join(ROOT, "MyRepo");
+  const r = resolvePerProjectBrain({
+    cwd: "/p/MyRepo",
+    projectsRoot: ROOT,
+    // Case-insensitive FS: every case variant probes the one physical dir.
+    storeExists: (dir) => dir === canonicalDir || dir === legacyDir,
+    hasIndex: (dir) => dir === canonicalDir || dir === legacyDir,
+    // realpath collapses both variants to the same underlying directory.
+    sameDir: () => true,
+    joinPath: join,
+  });
+  assert.equal(r.canonicalId, "myrepo");
+  assert.equal(r.legacyId, "MyRepo");
+  assert.equal(r.collision, false, "one physical dir reached by two names is not a split");
+  assert.equal(r.warning, null);
+  assert.equal(r.path, canonicalDir, "serve the canonical path for the single underlying store");
+});
+
+test("control: without the sameDir guard the same inputs WOULD read as a split", () => {
+  // Proves the guard (sameDir) is what suppresses the false positive — with
+  // sameDir defaulting to never-same, two case variants both 'exist' → split.
+  const canonicalDir = join(ROOT, "myrepo");
+  const legacyDir = join(ROOT, "MyRepo");
+  const r = resolvePerProjectBrain({
+    cwd: "/p/MyRepo",
+    projectsRoot: ROOT,
+    storeExists: (dir) => dir === canonicalDir || dir === legacyDir,
+    hasIndex: (dir) => dir === canonicalDir || dir === legacyDir,
+    joinPath: join, // no sameDir → defaults to () => false
+  });
+  assert.equal(r.collision, true);
+});
+
+// ---- #2: both stores degraded (no index) → serve the one that holds content ----
+// If neither store has a built `.brain.db` but one holds memory/*.md, the resolver
+// must serve the content-bearing store, not silently pick the empty canonical.
+
+test("both stores lack an index but legacy holds content → serve the content-bearing store", () => {
+  const canonicalDir = join(ROOT, "command-iq");
+  const legacyDir = join(ROOT, "command_iq");
+  const r = resolvePerProjectBrain({
+    cwd: "/p/command_iq",
+    projectsRoot: ROOT,
+    storeExists: (dir) => dir === canonicalDir || dir === legacyDir,
+    hasIndex: () => false,                       // neither has a built .brain.db
+    hasContent: (dir) => dir === legacyDir,      // only the legacy store has notes
+    sameDir: () => false,                        // genuinely distinct dirs
+    joinPath: join,
+  });
+  assert.equal(r.path, legacyDir, "must serve the store that actually holds content");
+  assert.equal(r.collision, true);
+  assert.match(r.warning, /split brain/);
+  assert.match(r.warning, /it holds content; canonical is empty/);
+});
+
+test("both stores empty (no index, no content) → tie-break to canonical", () => {
+  const canonicalDir = join(ROOT, "command-iq");
+  const legacyDir = join(ROOT, "command_iq");
+  const r = resolvePerProjectBrain({
+    cwd: "/p/command_iq",
+    projectsRoot: ROOT,
+    storeExists: (dir) => dir === canonicalDir || dir === legacyDir,
+    hasIndex: () => false,
+    hasContent: () => false,
+    sameDir: () => false,
+    joinPath: join,
+  });
+  assert.equal(r.path, canonicalDir, "genuinely-empty both → prefer canonical");
+  assert.equal(r.collision, true);
+});
+
+test("both stores lack an index but canonical holds content → keep canonical", () => {
+  const canonicalDir = join(ROOT, "command-iq");
+  const legacyDir = join(ROOT, "command_iq");
+  const r = resolvePerProjectBrain({
+    cwd: "/p/command_iq",
+    projectsRoot: ROOT,
+    storeExists: (dir) => dir === canonicalDir || dir === legacyDir,
+    hasIndex: () => false,
+    hasContent: (dir) => dir === canonicalDir,
+    sameDir: () => false,
+    joinPath: join,
+  });
+  assert.equal(r.path, canonicalDir);
+  assert.equal(r.collision, true);
+});

--- a/server/test/wicked-brain-call.test.mjs
+++ b/server/test/wicked-brain-call.test.mjs
@@ -508,6 +508,51 @@ test("path resolution uses the canonical (kebab) slug and warns on a split brain
     `expected split-brain warning on stderr, got: ${res.stderr}`);
 });
 
+test("a fresh canonical brain with only .gitkeep is NOT counted as populated (#56 review)", () => {
+  // wicked-brain:init scaffolds memory/.gitkeep, raw/.gitkeep and empty
+  // chunks/{extracted,inferred}. A naive "dir non-empty" check would treat that
+  // fresh CANONICAL store as populated, defeating split-brain protection and
+  // serving the empty brain over the user's populated LEGACY store (data loss).
+  const home = mkdtempSync(join(tmpdir(), "wb-home-"));
+  const projectsRoot = join(home, ".wicked-brain", "projects");
+  const cwdDir = mkdtempSync(join(tmpdir(), "repo_"));
+  const repoDir = join(cwdDir, "command_iq");
+  mkdirSync(repoDir, { recursive: true });
+
+  // LEGACY raw-basename store holds real content (a memory note, no built index).
+  const legacyDir = join(projectsRoot, "command_iq");
+  mkdirSync(join(legacyDir, "memory"), { recursive: true });
+  writeFileSync(join(legacyDir, "brain.json"), JSON.stringify({ id: "command-iq" }));
+  writeFileSync(join(legacyDir, "memory", "decision-jwt.md"), "# real memory\n");
+
+  // CANONICAL kebab store is a FRESH init: only .gitkeep + empty chunks scaffold.
+  const canonDir = join(projectsRoot, "command-iq");
+  mkdirSync(join(canonDir, "memory"), { recursive: true });
+  mkdirSync(join(canonDir, "raw"), { recursive: true });
+  mkdirSync(join(canonDir, "chunks", "extracted"), { recursive: true });
+  mkdirSync(join(canonDir, "chunks", "inferred"), { recursive: true });
+  writeFileSync(join(canonDir, "brain.json"), JSON.stringify({ id: "command-iq" }));
+  writeFileSync(join(canonDir, "memory", ".gitkeep"), "");
+  writeFileSync(join(canonDir, "raw", ".gitkeep"), "");
+
+  const res = spawnSync(
+    process.execPath,
+    [callBin, "--status"],
+    {
+      encoding: "utf-8",
+      cwd: repoDir,
+      env: { ...process.env, HOME: home, USERPROFILE: home, WICKED_BRAIN_PATH: "" },
+      timeout: 15_000,
+    },
+  );
+  assert.equal(res.status, 0, `status exit ${res.status}; stderr: ${res.stderr}`);
+  const parsed = tryJson(res.stdout || "");
+  assert.ok(parsed, `status not JSON: ${res.stdout}`);
+  // The .gitkeep-only canonical store must NOT count as populated — serve legacy.
+  assert.equal(basename(parsed.brain_path), "command_iq",
+    `resolved to ${parsed.brain_path}; a .gitkeep-only canonical store must not count as content`);
+});
+
 test("cold spawn derives --source from cwd when basename matches, and persists source_path", async () => {
   // Per-project brains are keyed on basename(cwd) — when the brain dir name
   // matches the cwd name and config has no source_path, the CLI passes cwd

--- a/server/test/wicked-brain-call.test.mjs
+++ b/server/test/wicked-brain-call.test.mjs
@@ -467,6 +467,47 @@ test("data path: matching brain_id lets the op THROUGH to the server", async () 
   }
 });
 
+test("path resolution uses the canonical (kebab) slug and warns on a split brain (#56)", () => {
+  // Reproduce the fragmentation: a repo dir with an underscore basename, a
+  // populated LEGACY raw-basename store, and an empty CANONICAL kebab store.
+  // The resolver must (a) NOT silently serve the empty canonical store, and
+  // (b) surface an actionable split-brain warning on stderr.
+  const home = mkdtempSync(join(tmpdir(), "wb-home-"));
+  const projectsRoot = join(home, ".wicked-brain", "projects");
+  const cwdDir = mkdtempSync(join(tmpdir(), "repo_")); // underscore-friendly parent
+  const repoDir = join(cwdDir, "command_iq");
+  mkdirSync(repoDir, { recursive: true });
+
+  const legacyDir = join(projectsRoot, "command_iq"); // raw basename, populated
+  const canonDir = join(projectsRoot, "command-iq");  // canonical, degraded
+  mkdirSync(join(legacyDir, "_meta"), { recursive: true });
+  writeFileSync(join(legacyDir, "brain.json"), JSON.stringify({ id: "command-iq" }));
+  writeFileSync(join(legacyDir, ".brain.db"), "not empty");
+  mkdirSync(join(canonDir, "_meta"), { recursive: true });
+  writeFileSync(join(canonDir, "brain.json"), JSON.stringify({ id: "command-iq" }));
+
+  // --status reads config only (no spawn); resolveBrainPath still runs.
+  const res = spawnSync(
+    process.execPath,
+    [callBin, "--status"],
+    {
+      encoding: "utf-8",
+      cwd: repoDir,
+      env: { ...process.env, HOME: home, USERPROFILE: home, WICKED_BRAIN_PATH: "" },
+      timeout: 15_000,
+    },
+  );
+  assert.equal(res.status, 0, `status exit ${res.status}; stderr: ${res.stderr}`);
+  const parsed = tryJson(res.stdout || "");
+  assert.ok(parsed, `status not JSON: ${res.stdout}`);
+  // Must serve the POPULATED legacy store, not the empty canonical one.
+  assert.equal(basename(parsed.brain_path), "command_iq",
+    `resolved to ${parsed.brain_path}, expected the populated legacy store`);
+  // Actionable split-brain warning on stderr.
+  assert.match(res.stderr, /WARNING: split brain/,
+    `expected split-brain warning on stderr, got: ${res.stderr}`);
+});
+
 test("cold spawn derives --source from cwd when basename matches, and persists source_path", async () => {
   // Per-project brains are keyed on basename(cwd) — when the brain dir name
   // matches the cwd name and config has no source_path, the CLI passes cwd

--- a/skills/wicked-brain-init/SKILL.md
+++ b/skills/wicked-brain-init/SKILL.md
@@ -60,8 +60,12 @@ will land in the project root.
 
 To locate the brain config for the current session:
 
-1. Compute `{cwd_basename}` — the basename of the current working directory,
-   lowercased, with non-alphanumerics replaced by hyphens.
+1. Compute `{cwd_basename}` — the basename of the current working directory run
+   through the canonical slug rule (`projectId()` in
+   `server/lib/project-id.mjs`; the full rule — NFKD fold, lowercase,
+   non-alphanumerics → hyphens, empty-fold `brain-<sha1>` fallback — is spelled
+   out under Step 1 below). For ordinary names this is just lowercase +
+   non-alphanumerics → hyphens.
 2. Try `~/.wicked-brain/projects/{cwd_basename}/_meta/config.json` first
    (Windows: `%USERPROFILE%\.wicked-brain\projects\{cwd_basename}\_meta\config.json`).
 3. If that file doesn't exist, fall back to the legacy flat path
@@ -104,7 +108,33 @@ or any installed tool. For example:
 - User is in `/Users/mike/Projects/wicked-brain` → default name is `wicked-brain` (only
   correct if they are literally indexing the wicked-brain repo itself)
 
-Lowercase the result and replace non-alphanumeric characters with hyphens.
+Apply the **canonical slug rule** below. It is byte-for-byte identical to
+`projectId()` in `server/lib/project-id.mjs` — **that function is the single
+source of truth**; this text just mirrors it so an agent computing the slug by
+hand lands on the same dir the CLI resolves. For an ordinary ASCII repo name it
+reduces to "lowercase, non-alphanumerics → hyphens", but the full rule is:
+
+1. Unicode-normalize with **NFKD** and strip combining marks, folding accents and
+   compatibility forms toward ASCII (`café` → `cafe`, `Zürich` → `zurich`,
+   `ﬁnance` → `finance`).
+2. Lowercase.
+3. Replace every run of non-`[a-z0-9]` characters with a single hyphen.
+4. Trim leading and trailing hyphens.
+5. **Fallback:** if nothing survives (e.g. an all-CJK name folds to empty), use
+   `brain-` + the first 8 hex chars of `sha1(original name)`, so two distinct
+   names never collapse to the same empty slug.
+
+> **Canonical project id.** This is the ONE canonical slug for a repo, produced
+> by `projectId()` in `server/lib/project-id.mjs` — treat that function as
+> authoritative and do not re-derive a simpler rule. The id you pick here and the
+> dir `wicked-brain-call` auto-resolves therefore always match. Underscores and
+> spaces collapse to hyphens: `command_iq` and `My Repo` become `command-iq` and
+> `my-repo`. Do NOT keep the raw basename (e.g. `command_iq`) as the id — a raw-basename brain dir
+> and a kebab brain dir for the same repo is the split-brain fragmentation from
+> wicked-brain#56, where one repo's memory ends up scattered across two stores
+> and lookups silently resolve to the empty one. If you find both a raw-basename
+> dir and a kebab dir under `~/.wicked-brain/projects/` for the same repo, run
+> `wicked-brain:migrate` to merge them into the canonical (kebab) id.
 
 Then ask **two questions, in order**:
 

--- a/skills/wicked-brain-migrate/SKILL.md
+++ b/skills/wicked-brain-migrate/SKILL.md
@@ -29,6 +29,59 @@ Read/Write/Glob tools over shell commands when possible.
 - `wicked-brain:init` detected a flat brain and invoked this skill
 - Another skill hit errors caused by the flat layout (e.g. port collisions
   with a second project, meta-brain federation not working)
+- **Split-brain merge** — two per-project dirs map to the same canonical id for
+  one repo (e.g. `projects/command_iq` AND `projects/command-iq`). `wicked-brain:status`
+  or a `WARNING: split brain …` line from `wicked-brain-call` flags this. See
+  the "Slug-merge" mode below.
+
+## Slug-merge mode (two dirs, same repo — wicked-brain#56)
+
+Before the canonical `projectId()` slug landed, the CLI keyed per-project brains
+on the RAW cwd basename (`command_iq`, underscore preserved) while
+`wicked-brain:init` kebab-cased the id (`command-iq`). A single repo could end
+up with its memory fragmented across both dirs, and a lookup could silently
+resolve to the empty/degraded one. This mode merges them into the canonical id.
+
+**Canonical id** = the repo's cwd basename run through `projectId()` in
+`server/lib/project-id.mjs` (the single source of truth). For an ordinary ASCII
+name that is just lowercase + non-alphanumerics → hyphens (`command_iq` →
+`command-iq`); the full rule also NFKD-folds Unicode (`Zürich` → `zurich`) and
+falls back to `brain-<sha1>` for names that fold to empty — see the
+`wicked-brain:init` canonical rule for the exact steps. The canonical dir is
+always the kebab one.
+
+### Slug-merge process
+
+1. **Identify the two dirs.** Under `~/.wicked-brain/projects/`, find the
+   raw-basename dir and the canonical (kebab) dir that collapse to the same
+   canonical id. Read each `brain.json`, count `memory/*.md`, and check for
+   `.brain.db` so you know which store is richer.
+2. **Pick the survivor = the canonical (kebab) dir.** All data merges INTO it.
+   If only the raw dir has a `.brain.db`, that's fine — you'll move it over.
+3. **Stop any server on BOTH dirs** (same procedure as Step 3 below — read each
+   `_meta/server.pid`, verify liveness cross-platform, stop, wait, delete the
+   stale PID). SQLite files must not be locked during the move.
+4. **Merge data from the raw dir into the canonical dir.** For `memory/`,
+   `raw/`, `chunks/`, `wiki/`, `calls/`: move files that don't already exist in
+   the canonical dir; for name collisions keep BOTH (suffix the incoming file,
+   e.g. `-legacy`) — never overwrite. For `.brain.db`/`-shm`/`-wal`: if the
+   canonical dir has no `.brain.db`, move the raw dir's over; if BOTH have one,
+   move the canonical dir's index aside and rebuild after the merge (see step 6)
+   rather than trying to merge two SQLite files.
+5. **Never delete the raw dir until the merge is verified.** Rename it aside
+   (e.g. `command_iq.pre-merge`) so rollback stays possible.
+6. **Start the server on the canonical dir and `reindex`** so the SQLite index
+   reflects the merged files:
+   ```bash
+   npx wicked-brain-call --brain "~/.wicked-brain/projects/{canonical-id}" reindex
+   npx wicked-brain-call --brain "~/.wicked-brain/projects/{canonical-id}" stats
+   ```
+   Confirm the merged memory/chunk counts are the SUM (minus true duplicates) of
+   the two source dirs.
+7. **Only after verification, remove the renamed `…​.pre-merge` dir.** Report the
+   before/after counts and the surviving canonical path to the user.
+
+The rest of this skill covers the original **flat → per-project** migration.
 
 ## Parameters
 

--- a/skills/wicked-brain-status/SKILL.md
+++ b/skills/wicked-brain-status/SKILL.md
@@ -48,6 +48,40 @@ npx wicked-brain-call stats
 
 If the call exits with code 2 (infra failure), surface the error to the user.
 
+**Watch stderr for a split-brain warning.** `wicked-brain-call` writes a
+`WARNING: split brain …` / `WARNING: … legacy id …` line to stderr when more
+than one `~/.wicked-brain/projects/*` dir maps to the same canonical id for this
+repo (the wicked-brain#56 fragmentation). If you see it, surface it verbatim and
+tell the user to run `wicked-brain:migrate` to merge the stores.
+
+### Step 2b: Detect split-brain fragmentation
+
+Independently confirm the repo's memory isn't fragmented across sibling stores.
+Compute the canonical id for the current repo with the same `projectId()` rule
+the CLI and `wicked-brain:init` use (`projectId()` in
+`server/lib/project-id.mjs` is the source of truth). For an ordinary ASCII repo
+name that is just the cwd basename lowercased with non-alphanumerics replaced by
+hyphens (`command_iq` → `command-iq`); the full rule also NFKD-folds Unicode
+(`Zürich` → `zurich`) and falls back to `brain-<sha1>` for names that fold to
+empty — see the `wicked-brain:init` canonical rule for the exact steps. Then
+list `~/.wicked-brain/projects/` (Windows:
+`%USERPROFILE%\.wicked-brain\projects\`) with Glob or:
+- macOS/Linux: `ls ~/.wicked-brain/projects/`
+- Windows PowerShell: `Get-ChildItem "$env:USERPROFILE\.wicked-brain\projects"`
+
+Flag a collision when **more than one** directory maps to the same canonical id
+(e.g. both `command_iq` and `command-iq` exist), or when the resolved brain has
+**0 chunks / no `.brain.db`** while a sibling dir for the same repo has content:
+
+```
+⚠ Split brain: {raw-dir} and {canonical-dir} both hold this repo's memory
+  (canonical id: {canonical-id}). The current session may be reading the empty
+  one. Run wicked-brain:migrate to merge them into "{canonical-id}".
+```
+
+Fail loud here — never let the user conclude "the brain knows nothing" when a
+populated sibling store exists.
+
 ### Step 3: Return at requested depth
 
 **Depth 0:**


### PR DESCRIPTION
Fixes #56 — a repo's memory fragmenting across sibling brain stores.

## Problem
The CLI resolver keyed the per-project brain on the **raw cwd basename** (`command_iq`) while the init skill **kebab-cased** it (`command-iq`), so the same repo mapped to two different stores and a lookup could silently resolve to the empty one.

## Fix
One canonical kebab `projectId(cwd)` (pure module `server/lib/project-id.mjs`) shared by the CLI resolver **and** the init/status/migrate skills. A fragmentation-safe resolver never orphans data: fresh repo → canonical dir; legacy-only store → serve + warn; genuine split → serve the **populated** store (never the empty sibling) + actionable warning to migrate.

## Adversarial review (2 rounds) hardened
- **case-insensitive FS** (macOS APFS/Windows): a `realpath` same-dir guard so a case-only variant (`MyRepo`/`myrepo`) isn't mistaken for a split;
- **populated = built index OR on-disk content**, so a content-bearing store is never passed over for an empty one;
- **skills document the full canonical rule** (NFKD fold + `sha1` empty-fold fallback), naming `projectId()` as the single source of truth.

## Tests
`cd server && node --test` → **441 pass**. Adds 5 deterministic slug/resolver tests (case-only-not-split with a load-bearing control; legacy-content-wins; both-empty tie-break; canonical-content-keep) + a `spawnSync` split-brain integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)