### PR TITLE
fix(codegraph): extract dispatch/capability edges from skills/ layout (garden#916)

### DIFF
--- a/server/lib/codegraph-extractors/capability.mjs
+++ b/server/lib/codegraph-extractors/capability.mjs
@@ -1,15 +1,21 @@
 /**
- * codegraph-extractors/capability.mjs — agent→capability injected edges.
+ * codegraph-extractors/capability.mjs — agent/skill→capability injected edges.
  *
- * An agent declares needed capabilities via a `tool-capabilities:` YAML frontmatter
- * block list. This extractor reads those declarations and creates synthetic
- * `capability:<name>` nodes plus edges from the agent file to each capability.
+ * An agent (or, post-consolidation, a skill) declares needed capabilities via a
+ * `tool-capabilities:` YAML frontmatter block list. This extractor reads those
+ * declarations and creates synthetic `capability:<name>` nodes plus edges from the
+ * declaring file to each capability.
  *
- * Edge direction: source=agent (dependent) → target=capability (dependency).
- * DEPENDENTS_BY="target": blastRadius(capability) = WHERE target=capability → source=agent ✓
+ * Two layouts are supported (backward-compatible):
+ *   1. Legacy: agents/.../ markdown files with `tool-capabilities:` frontmatter.
+ *   2. Consolidated skills layout (wicked-garden's agents→skills cleanup): the same
+ *      `tool-capabilities:` frontmatter now lives in skills/.../SKILL.md files.
  *
- * Frontmatter-only port of wicked-garden's inject_capability_edges.py.
- * No capability registry is imported — brain stays dependency-free.
+ * Edge direction: source=agent/skill (dependent) → target=capability (dependency).
+ * DEPENDENTS_BY="target": blastRadius(capability) = WHERE target=capability → source=file ✓
+ *
+ * Frontmatter-only port of wicked-garden's inject_capability_edges.py, extended for
+ * the skills layout. No capability registry is imported — brain stays dependency-free.
  *
  * This extractor OWNS the capability nodes:
  *   - DELETE edges WHERE provenance='injected:capability'
@@ -101,11 +107,20 @@ export function extract({ db, sourcePath }) {
   let edges_added = 0;
   const distinctCaps = new Set();
 
-  // 2. Scan agents/**/*.md
-  const agentsDir = join(sourcePath, "agents");
-  const agentFiles = collectMdFiles(agentsDir);
+  // 2. Scan both layouts: legacy agents/**/*.md and consolidated skills/**/SKILL.md.
+  //    Dedup by relpath so a repo carrying both never double-counts a file.
+  const agentFiles = collectMdFiles(join(sourcePath, "agents"));
+  const skillFiles = collectMdFiles(join(sourcePath, "skills"))
+    .filter((p) => p.split(sep).pop() === "SKILL.md");
+  const seen = new Set();
+  const declaringFiles = [];
+  for (const absPath of [...agentFiles, ...skillFiles]) {
+    if (seen.has(absPath)) continue;
+    seen.add(absPath);
+    declaringFiles.push(absPath);
+  }
 
-  for (const absPath of agentFiles) {
+  for (const absPath of declaringFiles) {
     let text;
     try { text = readFileSync(absPath, "utf8"); } catch { continue; }
 

--- a/server/lib/codegraph-extractors/dispatch.mjs
+++ b/server/lib/codegraph-extractors/dispatch.mjs
@@ -87,7 +87,8 @@ function posixRel(sourcePath, abs) {
  * @returns {{ frontmatter: string, body: string }}
  */
 function splitFrontmatter(text) {
-  const m = text.match(/^---[ \t]*\n([\s\S]*?)\n---[ \t]*\n?/);
+  // `\r?\n` throughout so CRLF (Windows) SKILL.md files parse identically to LF.
+  const m = text.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/);
   if (m) return { frontmatter: m[1], body: text.slice(m[0].length) };
   return { frontmatter: "", body: text };
 }
@@ -99,7 +100,10 @@ function splitFrontmatter(text) {
  * @returns {string|null}
  */
 function frontmatterField(frontmatter, field) {
-  const re = new RegExp(`^${field}:[ \\t]*(.+?)[ \\t]*$`, "m");
+  // Trailing `[ \t\r]*` (not just `[ \t]*`) so a CRLF line's `\r` is stripped
+  // instead of captured into the value — otherwise a quoted `"value"\r` keeps
+  // its trailing quote (the strip below anchors `$` past the `\r`).
+  const re = new RegExp(`^${field}:[ \\t]*(.+?)[ \\t\\r]*$`, "m");
   const m = frontmatter.match(re);
   if (!m) return null;
   return m[1].replace(/^["']|["']$/g, "").trim() || null;
@@ -224,19 +228,23 @@ export function extract({ db, sourcePath }) {
       if (!targets.has(targetRel)) targets.set(targetRel, ref);
     }
 
-    for (const [targetRel, ref] of targets) {
+    // `relpath` is constant for this file — resolve its node once, and only if
+    // there's at least one target (ensureFileNode is an INSERT OR IGNORE write).
+    if (targets.size > 0) {
       const src = ensureFileNode(db, relpath);
-      const tgt = ensureFileNode(db, targetRel);
+      for (const [targetRel, ref] of targets) {
+        const tgt = ensureFileNode(db, targetRel);
 
-      insertEdge.run(
-        src,
-        tgt,
-        "references",
-        JSON.stringify({ injected: "dispatch", dispatch: ref }),
-        INJECTED_PROVENANCE
-      );
-      edges_added++;
-      dispatches++;
+        insertEdge.run(
+          src,
+          tgt,
+          "references",
+          JSON.stringify({ injected: "dispatch", dispatch: ref }),
+          INJECTED_PROVENANCE
+        );
+        edges_added++;
+        dispatches++;
+      }
     }
   }
 

--- a/server/lib/codegraph-extractors/dispatch.mjs
+++ b/server/lib/codegraph-extractors/dispatch.mjs
@@ -1,17 +1,29 @@
 /**
- * codegraph-extractors/dispatch.mjs — command→agent injected edges.
+ * codegraph-extractors/dispatch.mjs — dispatch injected edges (command/skill → agent/skill).
  *
- * A slash command dispatches to a subagent via a `subagent_type: <plugin>:<domain>:<name>`
- * string (in Task(subagent_type="...") or YAML frontmatter). The command file never
- * references the agent file — grep/static can't link them. This extractor injects
- * those edges so blast-radius traversal can surface the dispatching commands when
- * an agent changes.
+ * A dispatcher hands work to another agent. Two layouts express this, and this
+ * extractor supports both (backward-compatible):
  *
- * Edge direction: source=command (dependent) → target=agent (dependency).
- * DEPENDENTS_BY="target": blastRadius(agent) = WHERE target=agent → source=command ✓
+ *   1. Legacy commands/agents layout: a slash command under `commands/**` dispatches
+ *      via a `subagent_type: <plugin>:<domain>:<name>` string, resolved to the agent
+ *      file `agents/<domain>/<name>.md`.
  *
- * Port of wicked-garden's inject_dispatch_edges.py. Direction is already correct
- * in the garden version for our blast-radius convention (no reversal needed, unlike bus).
+ *   2. Consolidated skills layout (wicked-garden's agents→skills / commands→skill-actions
+ *      cleanup): every dispatchable unit is a skills/.../SKILL.md file. A skill declares its
+ *      own identity in frontmatter (`name:`, `subagent_type:`), and a *dispatching* skill
+ *      references another skill in its body via `Task(subagent_type="plugin:domain:name")`
+ *      or `Skill(skill="wicked-garden-<domain>-<role>")`. Those cross-skill references
+ *      become dispatch edges.
+ *
+ * The referencing file never links the target file — grep/static can't join them. This
+ * extractor injects the edges so blast-radius traversal surfaces the dispatchers when a
+ * target agent/skill changes.
+ *
+ * Edge direction: source=dispatcher (dependent) → target=agent/skill (dependency).
+ * DEPENDENTS_BY="target": blastRadius(target) = WHERE target=target → source=dispatcher ✓
+ *
+ * Port of wicked-garden's inject_dispatch_edges.py, extended for the skills layout.
+ * Direction is already correct for our blast-radius convention (no reversal, unlike bus).
  */
 
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
@@ -21,8 +33,16 @@ import { ensureFileNode } from "../codegraph-nodes.mjs";
 const INJECTED_PROVENANCE = "injected:dispatch";
 
 // Matches subagent_type: "plugin:domain:name" or subagent_type="plugin:domain:name"
-// (with or without quotes, colon or equals separator)
+// (with or without quotes, colon or equals separator).
 const SUBAGENT_RE = /subagent_type\s*[:=]\s*["']?([a-z0-9_-]+:[a-z0-9_-]+:[a-z0-9_-]+)["']?/g;
+
+// Matches a Skill(...) dispatch call, capturing the first skill identifier argument:
+//   Skill(skill="wicked-garden-crew-reviewer", ...)
+//   Skill("wicked-garden:jam:council")
+//   Skill(wicked-garden:platform:prereq-doctor, ...)
+// Template placeholders (Skill(skill="wicked-garden-{domain}-{role}")) capture only the
+// literal prefix and simply fail to resolve against the skill index, so they're ignored.
+const SKILL_CALL_RE = /Skill\(\s*(?:skill\s*=\s*)?["']?([a-z0-9_:-]+)["']?/g;
 
 /**
  * Recursively collect all .md files under dir.
@@ -47,7 +67,46 @@ function collectMdFiles(dir) {
 }
 
 /**
- * Given a handle `plugin:domain:name`, resolve to the agent relpath
+ * Recursively collect all SKILL.md files under dir.
+ * @param {string} dir
+ * @returns {string[]} absolute file paths
+ */
+function collectSkillFiles(dir) {
+  return collectMdFiles(dir).filter((p) => p.split(sep).pop() === "SKILL.md");
+}
+
+/** POSIX relpath of abs relative to sourcePath. */
+function posixRel(sourcePath, abs) {
+  return relative(sourcePath, abs).split(sep).join("/");
+}
+
+/**
+ * Split a markdown file into YAML frontmatter and body.
+ * Returns { frontmatter, body }; frontmatter is "" when no leading --- fence.
+ * @param {string} text
+ * @returns {{ frontmatter: string, body: string }}
+ */
+function splitFrontmatter(text) {
+  const m = text.match(/^---[ \t]*\n([\s\S]*?)\n---[ \t]*\n?/);
+  if (m) return { frontmatter: m[1], body: text.slice(m[0].length) };
+  return { frontmatter: "", body: text };
+}
+
+/**
+ * Read a single-line scalar field from frontmatter text, stripping quotes.
+ * @param {string} frontmatter
+ * @param {string} field
+ * @returns {string|null}
+ */
+function frontmatterField(frontmatter, field) {
+  const re = new RegExp(`^${field}:[ \\t]*(.+?)[ \\t]*$`, "m");
+  const m = frontmatter.match(re);
+  if (!m) return null;
+  return m[1].replace(/^["']|["']$/g, "").trim() || null;
+}
+
+/**
+ * Given a handle `plugin:domain:name`, resolve to the legacy agent relpath
  * `agents/<domain>/<name>.md`. Returns the relpath if the file exists, else null.
  * @param {string} sourcePath
  * @param {string} handle  e.g. "wicked-garden:d:my-agent"
@@ -63,7 +122,32 @@ function resolveHandle(sourcePath, handle) {
 }
 
 /**
- * Extract command→agent dispatch injected edges into the codegraph DB.
+ * Build a lookup from skill identifiers to their SKILL.md relpath.
+ * Indexes each skill by its frontmatter `name:` (dir-name form, e.g.
+ * `wicked-garden-crew-reviewer`) and its `subagent_type:` handle (e.g.
+ * `wicked-garden:crew:reviewer`) — the two forms a dispatcher may reference by.
+ *
+ * @param {string} sourcePath
+ * @param {string[]} skillFiles  absolute SKILL.md paths
+ * @returns {Map<string, string>} identifier → relpath
+ */
+function buildSkillIndex(sourcePath, skillFiles) {
+  const index = new Map();
+  for (const absPath of skillFiles) {
+    let text;
+    try { text = readFileSync(absPath, "utf8"); } catch { continue; }
+    const relpath = posixRel(sourcePath, absPath);
+    const { frontmatter } = splitFrontmatter(text);
+    const name = frontmatterField(frontmatter, "name");
+    const handle = frontmatterField(frontmatter, "subagent_type");
+    if (name) index.set(name, relpath);
+    if (handle) index.set(handle, relpath);
+  }
+  return index;
+}
+
+/**
+ * Extract dispatch injected edges into the codegraph DB.
  *
  * @param {{ db: import("better-sqlite3").Database, sourcePath: string }} opts
  * @returns {{ edges_added: number, dispatches: number }}
@@ -79,27 +163,20 @@ export function extract({ db, sourcePath }) {
   let edges_added = 0;
   let dispatches = 0;
 
-  // 2. Scan commands/**/*.md
-  const commandsDir = join(sourcePath, "commands");
-  const commandFiles = collectMdFiles(commandsDir);
+  // ── Legacy layout: commands/**/*.md → agents/<domain>/<name>.md ──────────────
+  const commandFiles = collectMdFiles(join(sourcePath, "commands"));
 
   for (const absPath of commandFiles) {
     let text;
     try { text = readFileSync(absPath, "utf8"); } catch { continue; }
+    const relpath = posixRel(sourcePath, absPath);
 
-    // Posix relpath relative to sourcePath
-    const relpath = relative(sourcePath, absPath).split(sep).join("/");
-
-    // 3. Find distinct handles in this file
     SUBAGENT_RE.lastIndex = 0;
     const handles = new Set();
     let m;
-    while ((m = SUBAGENT_RE.exec(text)) !== null) {
-      handles.add(m[1]);
-    }
+    while ((m = SUBAGENT_RE.exec(text)) !== null) handles.add(m[1]);
 
     for (const handle of handles) {
-      // 4. Resolve handle to agent file
       const agentRelpath = resolveHandle(sourcePath, handle);
       if (!agentRelpath) continue; // not an agent file, or file doesn't exist
 
@@ -111,6 +188,51 @@ export function extract({ db, sourcePath }) {
         tgt,
         "references",
         JSON.stringify({ injected: "dispatch", subagent_type: handle }),
+        INJECTED_PROVENANCE
+      );
+      edges_added++;
+      dispatches++;
+    }
+  }
+
+  // ── Consolidated layout: skills/**/SKILL.md → skills/**/SKILL.md ─────────────
+  const skillFiles = collectSkillFiles(join(sourcePath, "skills"));
+  const skillIndex = buildSkillIndex(sourcePath, skillFiles);
+
+  for (const absPath of skillFiles) {
+    let text;
+    try { text = readFileSync(absPath, "utf8"); } catch { continue; }
+    const relpath = posixRel(sourcePath, absPath);
+    const { body } = splitFrontmatter(text);
+
+    // Collect referenced identifiers from the body only (frontmatter carries the
+    // skill's own identity, not its dispatches).
+    const refs = new Set();
+    SUBAGENT_RE.lastIndex = 0;
+    let m;
+    while ((m = SUBAGENT_RE.exec(body)) !== null) refs.add(m[1]);
+    SKILL_CALL_RE.lastIndex = 0;
+    while ((m = SKILL_CALL_RE.exec(body)) !== null) refs.add(m[1]);
+
+    // Resolve each reference to a target skill, deduped by target relpath so a
+    // handle + name pointing at the same skill yields a single edge.
+    const targets = new Map(); // targetRelpath → the identifier that resolved it
+    for (const ref of refs) {
+      const targetRel = skillIndex.get(ref);
+      if (!targetRel) continue;      // external plugin, template, or unknown → skip
+      if (targetRel === relpath) continue; // self-reference (compat note) → skip
+      if (!targets.has(targetRel)) targets.set(targetRel, ref);
+    }
+
+    for (const [targetRel, ref] of targets) {
+      const src = ensureFileNode(db, relpath);
+      const tgt = ensureFileNode(db, targetRel);
+
+      insertEdge.run(
+        src,
+        tgt,
+        "references",
+        JSON.stringify({ injected: "dispatch", dispatch: ref }),
         INJECTED_PROVENANCE
       );
       edges_added++;

--- a/server/test/codegraph-capability.test.mjs
+++ b/server/test/codegraph-capability.test.mjs
@@ -271,3 +271,92 @@ tool-capabilities:
     rmSync(repo, { recursive: true, force: true });
   }
 });
+
+// ─── Skills layout (agents→skills consolidation) ──────────────────────────────
+
+test("capability/skills: SKILL.md tool-capabilities frontmatter → edges + cap nodes", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "skills/platform-security-engineer/SKILL.md", `---
+name: wicked-garden-platform-security-engineer
+subagent_type: wicked-garden:platform:security-engineer
+context: fork
+allowed-tools: Read, Grep, Glob, Bash
+tool-capabilities:
+  - security-scanning
+  - version-control
+---
+# Security Engineer
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 2, "two capability edges from the skill");
+    assert.equal(result.capabilities, 2);
+
+    const edges = db.prepare(
+      "SELECT * FROM edges WHERE provenance = 'injected:capability' ORDER BY target"
+    ).all();
+    assert.equal(edges.length, 2);
+    for (const edge of edges) {
+      assert.equal(edge.source, "file:skills/platform-security-engineer/SKILL.md");
+    }
+    const targets = edges.map((e) => e.target).sort();
+    assert.deepEqual(targets, [
+      "capability:security-scanning",
+      "capability:version-control",
+    ]);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability/skills: non-SKILL.md files under skills/ are ignored", () => {
+  const { repo, db } = makeRepo();
+  try {
+    // A refs/*.md doc that happens to contain a tool-capabilities block must NOT
+    // be treated as a capability-declaring agent.
+    writeFile(repo, "skills/foo/refs/notes.md", `---
+tool-capabilities:
+  - should-not-count
+---
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 0);
+    assert.equal(result.capabilities, 0);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("capability/skills: end-to-end blastRadius — capability surfaces the declaring skill", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "skills/agentic-safety-reviewer/SKILL.md", `---
+name: wicked-garden-agentic-safety-reviewer
+tool-capabilities:
+  - security-scanning
+---
+# Safety Reviewer
+`);
+
+    extract({ db, sourcePath: repo });
+    db.close();
+
+    const client = new CodegraphClient(repo);
+    try {
+      const result = client.blastRadius({ node: "capability:security-scanning" });
+      const ids = result.dependents.map((n) => n.id);
+      assert.ok(
+        ids.includes("file:skills/agentic-safety-reviewer/SKILL.md"),
+        `Expected declaring skill in dependents; got: ${JSON.stringify(ids)}`
+      );
+    } finally {
+      client.close();
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/server/test/codegraph-dispatch.test.mjs
+++ b/server/test/codegraph-dispatch.test.mjs
@@ -272,6 +272,46 @@ subagent_type: wicked-garden:crew:reviewer
   }
 });
 
+test("dispatch/skills: CRLF line endings + quoted frontmatter name still resolve", () => {
+  const { repo, db } = makeRepo();
+  try {
+    // Windows-style CRLF throughout, with a QUOTED target name — the exact
+    // combination that used to break: `\r` was captured into the value and the
+    // trailing quote survived the strip, so the skill-index key was wrong
+    // (`wicked-garden-crew-reviewer"\r`) and the dispatch edge never resolved.
+    const crlf = (lines) => lines.join("\r\n");
+    writeFile(repo, "skills/jam-council/SKILL.md", crlf([
+      "---",
+      "name: wicked-garden-jam-council",
+      "subagent_type: wicked-garden:jam:council",
+      "context: fork",
+      "---",
+      "# Council",
+      'Skill(skill="wicked-garden-crew-reviewer", args="reviewer seat")',
+      "",
+    ]));
+    writeFile(repo, "skills/crew-reviewer/SKILL.md", crlf([
+      "---",
+      'name: "wicked-garden-crew-reviewer"',
+      "subagent_type: wicked-garden:crew:reviewer",
+      "---",
+      "# Reviewer",
+      "",
+    ]));
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 1, "CRLF + quoted name must still resolve the dispatch edge");
+    assert.equal(result.dispatches, 1);
+
+    const edge = db.prepare("SELECT * FROM edges WHERE provenance = 'injected:dispatch'").get();
+    assert.equal(edge.source, "file:skills/jam-council/SKILL.md");
+    assert.equal(edge.target, "file:skills/crew-reviewer/SKILL.md");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test("dispatch/skills: Task(subagent_type=\"handle\") body ref resolves via frontmatter index", () => {
   const { repo, db } = makeRepo();
   try {

--- a/server/test/codegraph-dispatch.test.mjs
+++ b/server/test/codegraph-dispatch.test.mjs
@@ -231,3 +231,177 @@ test("dispatch: end-to-end blastRadius — agent surfaces the dispatching comman
     rmSync(repo, { recursive: true, force: true });
   }
 });
+
+// ─── Skills layout (agents→skills / commands→skill-actions consolidation) ──────
+
+test("dispatch/skills: Skill(skill=\"<name>\") body ref → edge to that skill", () => {
+  const { repo, db } = makeRepo();
+  try {
+    // Dispatcher skill references another skill by its frontmatter `name:` form.
+    writeFile(repo, "skills/jam-council/SKILL.md", `---
+name: wicked-garden-jam-council
+subagent_type: wicked-garden:jam:council
+context: fork
+---
+# Council
+Dispatch each seat as the forked reviewer skill:
+Skill(skill="wicked-garden-crew-reviewer",
+      args="You are the COUNCIL's reviewer seat.")
+`);
+    writeFile(repo, "skills/crew-reviewer/SKILL.md", `---
+name: wicked-garden-crew-reviewer
+subagent_type: wicked-garden:crew:reviewer
+---
+# Reviewer
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 1, "one dispatch edge from council → reviewer");
+    assert.equal(result.dispatches, 1);
+
+    const edge = db.prepare("SELECT * FROM edges WHERE provenance = 'injected:dispatch'").get();
+    assert.equal(edge.source, "file:skills/jam-council/SKILL.md");
+    assert.equal(edge.target, "file:skills/crew-reviewer/SKILL.md");
+    assert.equal(edge.kind, "references");
+    const meta = JSON.parse(edge.metadata);
+    assert.equal(meta.injected, "dispatch");
+    assert.equal(meta.dispatch, "wicked-garden-crew-reviewer");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch/skills: Task(subagent_type=\"handle\") body ref resolves via frontmatter index", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "skills/orchestrator/SKILL.md", `---
+name: wicked-garden-orchestrator
+subagent_type: wicked-garden:core:orchestrator
+---
+# Orchestrator
+Delegate the security pass:
+Task(subagent_type="wicked-garden:platform:security-engineer")
+`);
+    writeFile(repo, "skills/platform-security-engineer/SKILL.md", `---
+name: wicked-garden-platform-security-engineer
+subagent_type: wicked-garden:platform:security-engineer
+---
+# Security Engineer
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 1);
+
+    const edge = db.prepare("SELECT * FROM edges WHERE provenance = 'injected:dispatch'").get();
+    assert.equal(edge.source, "file:skills/orchestrator/SKILL.md");
+    assert.equal(edge.target, "file:skills/platform-security-engineer/SKILL.md");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch/skills: self-reference (frontmatter compat note) is skipped", () => {
+  const { repo, db } = makeRepo();
+  try {
+    // The agent-style skill documents its own compat handle in the body — must NOT
+    // produce a self-edge.
+    writeFile(repo, "skills/platform-security-engineer/SKILL.md", `---
+name: wicked-garden-platform-security-engineer
+subagent_type: wicked-garden:platform:security-engineer
+---
+# Security Engineer
+Subagent form: Task(subagent_type="wicked-garden:platform:security-engineer")
+maps to this fork skill. Also Skill(skill="wicked-garden-platform-security-engineer").
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 0, "self-references produce no edges");
+    assert.equal(result.dispatches, 0);
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch/skills: refs to external plugins / templates are skipped", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "skills/ground/SKILL.md", `---
+name: wicked-garden-ground
+---
+# Ground
+Skill(wicked-brain:query, question="{q}")
+Skill(skill="wicked-garden-{domain}-{role}")
+Skill("superpowers:systematic-debugging")
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 0, "external/template refs don't resolve to a skill");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch/skills: handle + name to same target yields a single edge", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "skills/dispatcher/SKILL.md", `---
+name: wicked-garden-dispatcher
+---
+# Dispatcher
+Task(subagent_type="wicked-garden:crew:reviewer")
+Skill(skill="wicked-garden-crew-reviewer")
+`);
+    writeFile(repo, "skills/crew-reviewer/SKILL.md", `---
+name: wicked-garden-crew-reviewer
+subagent_type: wicked-garden:crew:reviewer
+---
+# Reviewer
+`);
+
+    const result = extract({ db, sourcePath: repo });
+    assert.equal(result.edges_added, 1, "deduped by target skill — one edge, not two");
+  } finally {
+    db.close();
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch/skills: end-to-end blastRadius — target skill surfaces the dispatcher", () => {
+  const { repo, db } = makeRepo();
+  try {
+    writeFile(repo, "skills/jam-council/SKILL.md", `---
+name: wicked-garden-jam-council
+subagent_type: wicked-garden:jam:council
+---
+# Council
+Skill(skill="wicked-garden-crew-reviewer")
+`);
+    writeFile(repo, "skills/crew-reviewer/SKILL.md", `---
+name: wicked-garden-crew-reviewer
+subagent_type: wicked-garden:crew:reviewer
+---
+# Reviewer
+`);
+
+    extract({ db, sourcePath: repo });
+    db.close();
+
+    const client = new CodegraphClient(repo);
+    try {
+      const result = client.blastRadius({ node: "file:skills/crew-reviewer/SKILL.md" });
+      const ids = result.dependents.map((n) => n.id);
+      assert.ok(
+        ids.includes("file:skills/jam-council/SKILL.md"),
+        `Expected file:skills/jam-council/SKILL.md in dependents; got: ${JSON.stringify(ids)}`
+      );
+    } finally {
+      client.close();
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes mikeparcewski/wicked-garden#916.

## Problem
Garden's agents→skills / commands→skill-actions consolidation deleted the `commands/` + `agents/` dirs that brain's dispatch + capability codegraph extractors scanned, so garden's blast-radius **dispatch/capability edges never materialized** (dispatch +0 skipped 9, capability +0 skipped 9).

## Fix
Extend both built-in extractors to also derive the same edges from `skills/**/SKILL.md` (the new location), keeping the legacy commands/agents scan for back-compat:
- **dispatch**: skill-identity index from frontmatter (`name` + `subagent_type`) → body scan for `Task(subagent_type=)` / `Skill(skill=)` cross-skill refs → source→target edges (self/external/template refs skipped, deduped).
- **capability**: also scan `skills/**/SKILL.md` `tool-capabilities` frontmatter.

Verified on the **real garden repo**: dispatch edges **0→7**, capability **0→5** (3 distinct caps).

## Tests
`cd server && node --test` → **452 pass** (+9 skills-layout tests). Adversarial review: **approved**, no regressions.

Follow-up (out of scope): injected edges are wiped on `codegraph index` re-run — nothing re-applies them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)