### PR TITLE
chore: dash-prefix skill names for cross-CLI resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ Two components:
 
 ### Skills (Markdown)
 - Each skill is a `SKILL.md` with YAML frontmatter (`name`, `description`).
-- Skill names use `wicked-brain:` prefix (e.g., `wicked-brain:search`).
-- Directory names use `wicked-brain-` prefix (colons aren't valid in dir names).
+- Skill frontmatter `name:` uses the `wicked-brain-` dash prefix (e.g., `wicked-brain-search`) — it must match the installed directory name so every CLI resolves the skill. A colon `name:` (`wicked-brain:search`) breaks the non-Claude hosts that rewrite `:`→`-` in directory names, producing a name/dir mismatch that drops the skill.
+- Directory names use the same `wicked-brain-` prefix; `name` == dir on every CLI.
 - Skills must be cross-platform: use agent-native tools (Read, Write, Grep, Glob) over shell commands. When shell is needed, provide macOS/Linux + Windows alternatives.
 - Skills include a "Cross-Platform Notes" section.
 - `curl` is cross-platform (Windows 10+) — OK to use for server API calls.
@@ -60,7 +60,7 @@ Two components:
 ### Naming
 - Package: `wicked-brain` (skills + installer)
 - Server: `wicked-brain-server` (npm package)
-- Skills: `wicked-brain:{operation}` (e.g., `wicked-brain:search`)
+- Skills: `wicked-brain-{operation}` (e.g., `wicked-brain-search`) — frontmatter `name` matches the directory
 - Directories: `wicked-brain-{operation}` (e.g., `wicked-brain-search/`)
 - Never use the old `fs-brain` or `brain-` names.
 

--- a/skills/wicked-brain-consolidate/SKILL.md
+++ b/skills/wicked-brain-consolidate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: wicked-brain:consolidate
+name: wicked-brain-consolidate
 description: |
   Multi-pass brain consolidation - archive noise, promote patterns, merge
   duplicates, build synonym map.

--- a/skills/wicked-brain-context/SKILL.md
+++ b/skills/wicked-brain-context/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: wicked-brain:context
+name: wicked-brain-context
 description: |
   Surface relevant brain knowledge for the current prompt. Tiered routing - hot
   path for simple prompts, fast path for complex.

--- a/skills/wicked-brain-context/hooks/claude-hooks.json
+++ b/skills/wicked-brain-context/hooks/claude-hooks.json
@@ -1,11 +1,11 @@
 {
-  "_comment": "wicked-brain context assembly hook — invoke wicked-brain:context on each prompt",
+  "_comment": "wicked-brain context assembly hook — invoke wicked-brain-context on each prompt",
   "hooks": {
     "UserPromptSubmit": [{
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "python3 -c \"import json,sys; sys.stdout.write(json.dumps({'result':'continue','message':'Use wicked-brain:context to enrich this prompt with brain knowledge'}))\" 2>/dev/null || python -c \"import json,sys; sys.stdout.write(json.dumps({'result':'continue','message':'Use wicked-brain:context to enrich this prompt with brain knowledge'}))\""
+        "command": "python3 -c \"import json,sys; sys.stdout.write(json.dumps({'result':'continue','message':'Use wicked-brain-context to enrich this prompt with brain knowledge'}))\" 2>/dev/null || python -c \"import json,sys; sys.stdout.write(json.dumps({'result':'continue','message':'Use wicked-brain-context to enrich this prompt with brain knowledge'}))\""
       }]
     }]
   }

--- a/skills/wicked-brain-context/hooks/copilot-hooks.json
+++ b/skills/wicked-brain-context/hooks/copilot-hooks.json
@@ -3,7 +3,7 @@
   "version": 1,
   "hooks": {
     "userPromptSubmitted": [{
-      "command": "echo 'Use wicked-brain:context to enrich this prompt with brain knowledge'",
+      "command": "echo 'Use wicked-brain-context to enrich this prompt with brain knowledge'",
       "timeout": 30
     }]
   }

--- a/skills/wicked-brain-context/hooks/gemini-hooks.json
+++ b/skills/wicked-brain-context/hooks/gemini-hooks.json
@@ -4,7 +4,7 @@
     "BeforeAgent": [{
       "hooks": [{
         "type": "command",
-        "command": "echo 'Use wicked-brain:context to enrich this prompt with brain knowledge'",
+        "command": "echo 'Use wicked-brain-context to enrich this prompt with brain knowledge'",
         "timeout": 5000
       }]
     }]

--- a/skills/wicked-brain-onboard/SKILL.md
+++ b/skills/wicked-brain-onboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: wicked-brain:onboard
+name: wicked-brain-onboard
 description: |
   Full project understanding - detect repo mode, scan, investigate 5
   perspectives, extract symbols, ingest chunks, compile support wiki,

--- a/skills/wicked-brain-session-teardown/SKILL.md
+++ b/skills/wicked-brain-session-teardown/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: wicked-brain:session-teardown
+name: wicked-brain-session-teardown
 description: |
   Capture session learnings - decisions, patterns, gotchas, discoveries - as
   brain memories before session ends.


### PR DESCRIPTION
## What

Change skill frontmatter `name:` from the colon form (`wicked-brain:context`) to the **dash** form (`wicked-brain-context`) so `name` == installed directory on every CLI.

## Why

Non-Claude hosts (Antigravity / Codex / OpenCode / Pi) rewrite `:`→`-` in installed skill directory names. A colon `name:` then no longer matches the directory, so those hosts see a name/dir mismatch and **silently drop the skill**. The dash form makes `name` == dir everywhere.

brain installs as **personal skills** (no `plugin.json`), so there is no colon `plugin:skill` dispatch contract to preserve — every reference goes dash, including the three per-CLI context hooks (`claude`/`copilot`/`gemini`).

## Scope

- 4 skill `SKILL.md` frontmatter names → dash
- 3 per-CLI context-hook JSON files → dash invocation strings
- `CLAUDE.md` naming rules corrected (`name` == dir, both dash)

Part of the ecosystem-wide colon→dash fix (also in wicked-testing, wicked-bus). Matches the pattern wicked-garden already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpniabdmx6H4HsjLTjFd1x