### PR TITLE
refactor(events): migrate brain event types to 4-segment grammar

### DIFF
--- a/docs/wiki/_generated/files.json
+++ b/docs/wiki/_generated/files.json
@@ -273,7 +273,7 @@
     },
     {
       "path": "server/lib/memory-promoter.mjs",
-      "purpose": "Promotion policy for auto-memorizing wicked.fact.extracted bus events.",
+      "purpose": "Promotion policy for auto-memorizing wicked.garden.fact.extracted bus events.",
       "exports": [
         "computeContentHash",
         "promoteFact",

--- a/docs/wiki/map-files.md
+++ b/docs/wiki/map-files.md
@@ -40,7 +40,7 @@ Generated walk of `server/lib`, `server/bin`. Do not hand-edit — regenerate wi
 | `server/lib/lsp-manager.mjs` | Manages language server processes — spawn, health check, crash recovery, shutdown. | `LspManager` | `./lsp-protocol.mjs` |
 | `server/lib/lsp-protocol.mjs` | LSP JSON-RPC protocol over stdio. Handles Content-Length framing, request/response matching, and notifications. | `MessageReader`, `RpcClient`, `writeMessage` | — |
 | `server/lib/lsp-servers.mjs` | Known language servers map — 40+ servers covering 70+ extensions. Extensible via {brainPath}/_meta/lsp.json. | `KNOWN_SERVERS`, `getKnownExtensions`, `loadUserConfig`, `resolveServer` | — |
-| `server/lib/memory-promoter.mjs` | Promotion policy for auto-memorizing wicked.fact.extracted bus events. | `computeContentHash`, `promoteFact`, `slugify` | — |
+| `server/lib/memory-promoter.mjs` | Promotion policy for auto-memorizing wicked.garden.fact.extracted bus events. | `computeContentHash`, `promoteFact`, `slugify` | — |
 | `server/lib/memory-subscriber.mjs` | Auto-memorize subscriber: bridges wicked-bus fact events into brain memories. | `fastForwardStaleCursor`, `renderMemoryFile`, `startMemorySubscriber` | `./bus.mjs`, `./memory-promoter.mjs` |
 | `server/lib/mode-config.mjs` | Validate a mode.json body. Returns { ok, errors } — does not throw. Kept in lockstep with mode.schema.json. The schema is the canonical documentation; this is the runtime enforcement. | `MODE_FILE_PATH`, `diffMode`, `readModeFile`, `validateMode`, `writeModeFile` | — |
 | `server/lib/onboard-wiki.mjs` | Onboard-wiki orchestrator. | `formatOnboardResult`, `runOnboardWiki` | `./detect-mode.mjs`, `./mode-config.mjs`, `./stamp-pointer.mjs` |

--- a/server/bin/wicked-brain-server.mjs
+++ b/server/bin/wicked-brain-server.mjs
@@ -138,7 +138,7 @@ const actions = {
   health: () => ({ ...db.health(), read_only: readOnly }),
   search: (p) => {
     const result = db.search(p);
-    emitEvent("wicked.search.executed", "brain.search", {
+    emitEvent("wicked.brain.search.executed", "brain.search", {
       query: p.query, result_count: result.total_matches, brain_id: brainId,
     });
     // Stamp the responding brain on the envelope so a `wicked-brain-call search`
@@ -149,26 +149,26 @@ const actions = {
   },
   federated_search: (p) => {
     const result = db.federatedSearch(p);
-    emitEvent("wicked.search.executed", "brain.search", {
+    emitEvent("wicked.brain.search.executed", "brain.search", {
       query: p.query, federated: true, brain_id: brainId,
     });
     return { ...result, brain_id: brainId };
   },
   index: (p) => {
     db.index(p);
-    emitEvent("wicked.chunk.indexed", "brain.chunk", {
+    emitEvent("wicked.brain.chunk.indexed", "brain.chunk", {
       id: p.id, path: p.path, brain_id: brainId,
     });
   },
   remove: (p) => {
     db.remove(p.id);
-    emitEvent("wicked.chunk.removed", "brain.chunk", {
+    emitEvent("wicked.brain.chunk.removed", "brain.chunk", {
       id: p.id, brain_id: brainId,
     });
   },
   reindex: (p) => {
     db.reindex(p.docs);
-    emitEvent("wicked.brain.reindexed", "brain", {
+    emitEvent("wicked.brain.index.reindexed", "brain", {
       doc_count: p.docs.length, brain_id: brainId,
     });
   },
@@ -210,13 +210,13 @@ const actions = {
   contradictions: () => ({ links: db.contradictions() }),
   confirm_link: (p) => {
     const result = db.confirmLink(p.source_id, p.target_path, p.verdict);
-    emitEvent("wicked.link.confirmed", "brain.link", {
+    emitEvent("wicked.brain.link.confirmed", "brain.link", {
       source_id: p.source_id, target_path: p.target_path, verdict: p.verdict, brain_id: brainId,
     });
     // Surface contradictions on a dedicated event stream so downstream
     // consumers don't have to filter by verdict on the generic confirmed event.
     if (p.verdict === "contradict") {
-      emitEvent("wicked.link.contradicted", "brain.link", {
+      emitEvent("wicked.brain.link.contradicted", "brain.link", {
         source_id: p.source_id,
         target_path: p.target_path,
         confidence: result?.confidence ?? null,
@@ -232,7 +232,7 @@ const actions = {
   wiki_list: (p) => db.wikiList(p),
   verify_wiki: (p = {}) => {
     const result = db.verifyWiki(p);
-    emitEvent("wicked.wiki.verified", "brain.wiki", {
+    emitEvent("wicked.brain.wiki.verified", "brain.wiki", {
       brain_id: brainId,
       total: result.summary.total,
       stale: result.summary.stale,
@@ -267,7 +267,7 @@ const actions = {
       docs.push({ id: entry.rel, path: entry.rel, content });
     }
     db.reindex(docs);
-    emitEvent("wicked.brain.reonboarded", "brain", {
+    emitEvent("wicked.brain.index.reonboarded", "brain", {
       brain_id: brainId,
       indexed: docs.length,
       mode: onboard?.detection?.mode ?? null,
@@ -308,7 +308,7 @@ const actions = {
     }
     const removed = await purgeBrainContent(brainPath);
     db.reindex([]);
-    emitEvent("wicked.brain.purged", "brain", { brain_id: brainId, removed });
+    emitEvent("wicked.brain.index.purged", "brain", { brain_id: brainId, removed });
     return { removed };
   },
 };
@@ -414,7 +414,7 @@ try {
 process.stdout.write(`wicked-brain-server running on port ${port} (brain: ${brainId}, pid: ${pid})\n`);
 watcher.start();
 const busReady = await waitForBus();
-emitEvent("wicked.server.started", "brain.system", {
+emitEvent("wicked.brain.server.started", "brain.system", {
   brain_id: brainId, port, pid,
 });
 if (busReady) {

--- a/server/lib/bus.mjs
+++ b/server/lib/bus.mjs
@@ -46,7 +46,7 @@ const ready = init();
  * Emit an event to the bus.
  * Fire-and-forget — never throws, never blocks the caller.
  *
- * @param {string} eventType - e.g. "wicked.chunk.indexed"
+ * @param {string} eventType - e.g. "wicked.brain.chunk.indexed"
  * @param {string} subdomain - e.g. "brain.chunk"
  * @param {object} payload - event-specific data
  */

--- a/server/lib/memory-promoter.mjs
+++ b/server/lib/memory-promoter.mjs
@@ -1,5 +1,5 @@
 /**
- * Promotion policy for auto-memorizing wicked.fact.extracted bus events.
+ * Promotion policy for auto-memorizing wicked.garden.fact.extracted bus events.
  *
  * Pure function — no I/O, no side effects. Returns either a memory descriptor
  * (frontmatter + content + safeName + contentHash) or a skip reason.
@@ -43,7 +43,7 @@ function tierFromImportance(importance) {
  * @returns {{memory: object|null, skip: boolean, reason?: string}}
  */
 export function promoteFact(event) {
-  if (!event || event.event_type !== "wicked.fact.extracted") {
+  if (!event || event.event_type !== "wicked.garden.fact.extracted") {
     return { memory: null, skip: true, reason: "wrong event_type" };
   }
   const payload = event.payload || {};

--- a/server/lib/memory-subscriber.mjs
+++ b/server/lib/memory-subscriber.mjs
@@ -1,7 +1,7 @@
 /**
  * Auto-memorize subscriber: bridges wicked-bus fact events into brain memories.
  *
- * Subscribes to `wicked.fact.extracted` via wicked-bus durable cursors,
+ * Subscribes to `wicked.garden.fact.extracted` via wicked-bus durable cursors,
  * runs each event through the promoter policy, dedups by content hash,
  * and writes a memory file. The brain file watcher picks it up and indexes it.
  *
@@ -17,7 +17,7 @@ import { promoteFact } from "./memory-promoter.mjs";
 // locate its cursor for the TTL self-heal — keep them in one place so the two
 // can't drift.
 const PLUGIN = "wicked-brain";
-const FACT_FILTER = "wicked.fact.extracted";
+const FACT_FILTER = "wicked.garden.fact.extracted";
 
 /**
  * Start the auto-memorize subscriber.
@@ -78,7 +78,7 @@ export async function startMemorySubscriber({ brainPath, brainId, db }) {
       const fileContent = renderMemoryFile(result.memory);
       writeFileSync(filePath, fileContent, "utf-8");
 
-      emitEvent("wicked.memory.stored", "brain.memory", {
+      emitEvent("wicked.brain.memory.stored", "brain.memory", {
         path: `memory/${result.memory.safeName}`,
         type: result.memory.frontmatter.type,
         tier: result.memory.frontmatter.tier,
@@ -91,7 +91,7 @@ export async function startMemorySubscriber({ brainPath, brainId, db }) {
     },
     onDeadLetter: (event, reason) => {
       console.error(`[memory-subscriber] dead-lettered event ${event?.event_id}: ${reason}`);
-      emitEvent("wicked.memory.dead_lettered", "brain.memory", {
+      emitEvent("wicked.brain.memory.dead_lettered", "brain.memory", {
         event_id: event?.event_id,
         reason,
         brain_id: brainId,

--- a/server/test/memory-promoter.test.mjs
+++ b/server/test/memory-promoter.test.mjs
@@ -4,7 +4,7 @@ import { promoteFact, computeContentHash, slugify } from "../lib/memory-promoter
 
 function makeEvent(overrides = {}) {
   return {
-    event_type: "wicked.fact.extracted",
+    event_type: "wicked.garden.fact.extracted",
     event_id: "evt-1",
     domain: "wicked-garden",
     emitted_at: 1700000000000,
@@ -40,7 +40,7 @@ test("discovery event → episodic, importance 4, ttl 14", () => {
 });
 
 test("skipped: wrong event_type", () => {
-  const r = promoteFact(makeEvent({ event_type: "wicked.chunk.indexed" }));
+  const r = promoteFact(makeEvent({ event_type: "wicked.brain.chunk.indexed" }));
   assert.equal(r.skip, true);
   assert.equal(r.memory, null);
 });

--- a/server/test/memory-subscriber.test.mjs
+++ b/server/test/memory-subscriber.test.mjs
@@ -24,7 +24,7 @@ function makeBusDb({ events = [], cursorAt = null, plugin = "wicked-brain" } = {
   for (const id of events) insE.run(id);
   if (cursorAt !== null) {
     db.prepare("INSERT INTO subscriptions VALUES (?,?,?,?,?,?)").run(
-      "sub1", plugin, "subscriber", "wicked.fact.extracted", 1, null,
+      "sub1", plugin, "subscriber", "wicked.garden.fact.extracted", 1, null,
     );
     db.prepare("INSERT INTO cursors VALUES (?,?,?,?)").run("cur1", "sub1", cursorAt, null);
   }
@@ -39,7 +39,7 @@ test("repositions a cursor behind the TTL window to just before the oldest survi
   try {
     // oldest = 100 → reposition to 99 so the surviving events (100,150,200) are
     // still replayed rather than skipped.
-    const r = fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted");
+    const r = fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted");
     assert.deepEqual(r, { from: 5, to: 99 });
     assert.equal(cursorOf(db), 99);
   } finally {
@@ -50,7 +50,7 @@ test("repositions a cursor behind the TTL window to just before the oldest survi
 test("no-op when the cursor is within the window", () => {
   const db = makeBusDb({ events: [100, 150, 200], cursorAt: 150 });
   try {
-    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted"), null);
+    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted"), null);
     assert.equal(cursorOf(db), 150);
   } finally {
     db.close();
@@ -61,7 +61,7 @@ test("treats exactly oldest-1 as caught up (matches poll WB-003 boundary)", () =
   // oldest = 100, so WB-003 fires only when last_event_id < 99.
   const db = makeBusDb({ events: [100, 200], cursorAt: 99 });
   try {
-    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted"), null);
+    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted"), null);
     assert.equal(cursorOf(db), 99);
   } finally {
     db.close();
@@ -71,7 +71,7 @@ test("treats exactly oldest-1 as caught up (matches poll WB-003 boundary)", () =
 test("no-op when there are no events", () => {
   const db = makeBusDb({ events: [], cursorAt: 5 });
   try {
-    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted"), null);
+    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted"), null);
   } finally {
     db.close();
   }
@@ -80,7 +80,7 @@ test("no-op when there are no events", () => {
 test("no-op when no cursor exists yet (fresh subscriber)", () => {
   const db = makeBusDb({ events: [100, 200] });
   try {
-    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted"), null);
+    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted"), null);
   } finally {
     db.close();
   }
@@ -89,7 +89,7 @@ test("no-op when no cursor exists yet (fresh subscriber)", () => {
 test("ignores cursors for a different plugin", () => {
   const db = makeBusDb({ events: [100, 200], cursorAt: 5, plugin: "other-plugin" });
   try {
-    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted"), null);
+    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted"), null);
     assert.equal(cursorOf(db), 5); // untouched
   } finally {
     db.close();
@@ -99,7 +99,7 @@ test("ignores cursors for a different plugin", () => {
 test("never throws when the bus schema is missing", () => {
   const db = new Database(":memory:");
   try {
-    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.fact.extracted"), null);
+    assert.equal(fastForwardStaleCursor(db, "wicked-brain", "wicked.garden.fact.extracted"), null);
   } finally {
     db.close();
   }

--- a/server/test/server.test.mjs
+++ b/server/test/server.test.mjs
@@ -396,8 +396,8 @@ test("dlq_list parses string limit defensively (CLI/HTTP layer often passes stri
 
 test("confirm_link with verdict=contradict does not crash and returns ok", async () => {
   // No matching link exists; confirmLink returns null. The HTTP layer maps
-  // null to { ok: true }. The handler still fires both wicked.link.confirmed
-  // and (because verdict=contradict) wicked.link.contradicted — we can't
+  // null to { ok: true }. The handler still fires both wicked.brain.link.confirmed
+  // and (because verdict=contradict) wicked.brain.link.contradicted — we can't
   // observe the emit from here, but we verify the dispatch path is wired.
   const result = await api(port, "confirm_link", {
     source_id: "no-such-source",

--- a/skills/wicked-brain-compile/SKILL.md
+++ b/skills/wicked-brain-compile/SKILL.md
@@ -255,7 +255,7 @@ For each article written or updated, emit:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.article.compiled" \
+  --type "wicked.brain.article.compiled" \
   --domain "wicked-brain" \
   --subdomain "brain.wiki" \
   --payload '{"path":"{article_path}","brain_id":"{brain_id}","source_chunk_count":{N},"persona":"{synthesis_persona}"}' 2>/dev/null || true

--- a/skills/wicked-brain-configure/SKILL.md
+++ b/skills/wicked-brain-configure/SKILL.md
@@ -116,7 +116,7 @@ Brain search/query results include `source_type` and `path` fields:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.config.updated" \
+  --type "wicked.brain.config.updated" \
   --domain "wicked-brain" \
   --subdomain "brain.system" \
   --payload '{"config_file":"{path}","platform":"{detected_platform}","brain_id":"{brain_id}"}' 2>/dev/null || true

--- a/skills/wicked-brain-consolidate/SKILL.md
+++ b/skills/wicked-brain-consolidate/SKILL.md
@@ -186,7 +186,7 @@ bus is not installed, silently skip):
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.brain.consolidated" \
+  --type "wicked.brain.index.consolidated" \
   --domain "wicked-brain" \
   --subdomain "brain" \
   --payload '{"brain_id":"{brain_id}","archived":{N},"promoted":{M},"merged":{P}}' 2>/dev/null || true

--- a/skills/wicked-brain-dlq/SKILL.md
+++ b/skills/wicked-brain-dlq/SKILL.md
@@ -2,7 +2,7 @@
 name: wicked-brain-dlq
 description: |
   Inspect, replay, or drop dead-lettered events from wicked-brain's bus
-  subscriber. The auto-memorize subscriber consumes `wicked.fact.extracted`
+  subscriber. The auto-memorize subscriber consumes `wicked.garden.fact.extracted`
   and dead-letters events that exhaust their retry budget. Without this
   skill, those events sit untouched forever — a fixable handler bug
   silently loses every fact.

--- a/skills/wicked-brain-enhance/SKILL.md
+++ b/skills/wicked-brain-enhance/SKILL.md
@@ -136,7 +136,7 @@ For each inferred chunk created, emit:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.chunk.enhanced" \
+  --type "wicked.brain.chunk.enhanced" \
   --domain "wicked-brain" \
   --subdomain "brain.chunk" \
   --payload '{"path":"{chunk_path}","brain_id":"{brain_id}","topic":"{topic}","confidence":0.6}' 2>/dev/null || true

--- a/skills/wicked-brain-forget/SKILL.md
+++ b/skills/wicked-brain-forget/SKILL.md
@@ -88,7 +88,7 @@ Append to `{brain_path}/_meta/log.jsonl`:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.memory.archived" \
+  --type "wicked.brain.memory.archived" \
   --domain "wicked-brain" \
   --subdomain "brain.memory" \
   --payload '{"path":"{path}","id":"{id}","mode":"{mode}","reason":"{reason}"}' 2>/dev/null || true

--- a/skills/wicked-brain-init/SKILL.md
+++ b/skills/wicked-brain-init/SKILL.md
@@ -319,7 +319,7 @@ If wicked-bus is available, emit an initialization event:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.brain.initialized" \
+  --type "wicked.brain.index.initialized" \
   --domain "wicked-brain" \
   --subdomain "brain" \
   --payload '{"brain_id":"{id}","brain_path":"{brain_path}","name":"{name}"}' 2>/dev/null || true

--- a/skills/wicked-brain-memory/SKILL.md
+++ b/skills/wicked-brain-memory/SKILL.md
@@ -225,7 +225,7 @@ Append to `{brain_path}/_meta/log.jsonl`:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.memory.stored" \
+  --type "wicked.brain.memory.stored" \
   --domain "wicked-brain" \
   --subdomain "brain.memory" \
   --payload '{"path":"memory/{safe_name}.md","type":"{type}","tier":"{resolved tier}","brain_id":"{brain_id}"}' 2>/dev/null || true

--- a/skills/wicked-brain-migrate/SKILL.md
+++ b/skills/wicked-brain-migrate/SKILL.md
@@ -299,7 +299,7 @@ The flat path is now a pure container with only `projects/` beneath it.
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.schema.migrated" \
+  --type "wicked.brain.schema.migrated" \
   --domain "wicked-brain" \
   --subdomain "brain.system" \
   --payload '{"from":"{flat_path}","to":"{target_path}","brain_id":"{brain_id}","doc_count":{N}}' 2>/dev/null || true

--- a/skills/wicked-brain-query/SKILL.md
+++ b/skills/wicked-brain-query/SKILL.md
@@ -107,7 +107,7 @@ Sources:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.query.executed" \
+  --type "wicked.brain.query.executed" \
   --domain "wicked-brain" \
   --subdomain "brain.query" \
   --payload '{"question":"{question}","sources_found":{count},"brain_id":"{brain_id}"}' 2>/dev/null || true

--- a/skills/wicked-brain-retag/SKILL.md
+++ b/skills/wicked-brain-retag/SKILL.md
@@ -89,7 +89,7 @@ After all files are updated (not in dry_run mode), emit a single summary event:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.tag.backfilled" \
+  --type "wicked.brain.tag.backfilled" \
   --domain "wicked-brain" \
   --subdomain "brain.chunk" \
   --payload '{"files_updated":{N},"files_scanned":{total},"brain_id":"{brain_id}"}' 2>/dev/null || true

--- a/skills/wicked-brain-synonyms/SKILL.md
+++ b/skills/wicked-brain-synonyms/SKILL.md
@@ -138,7 +138,7 @@ After any write to `synonyms.json` (add, remove, or auto-suggest apply), emit:
 
 ```bash
 npx wicked-bus emit \
-  --type "wicked.synonym.updated" \
+  --type "wicked.brain.synonym.updated" \
   --domain "wicked-brain" \
   --subdomain "brain.taxonomy" \
   --payload '{"operation":"{add|remove|auto-apply}","term":"{term}","brain_id":"{brain_id}"}' 2>/dev/null || true


### PR DESCRIPTION
## What
Adopt the canonical **4-segment** grammar `wicked.<domain>.<noun>.<verb>` (per `wicked-bus/reqs/SPEC.md`). Brain's own events take the `brain` domain; the knowledge-index lifecycle groups under the `index` noun.

## ⚠️ Cross-repo — closes the wicked-garden ↔ wicked-brain edges
Names match garden's already-migrated consumers/emitter **byte-for-byte**:
| direction | old | new | garden side |
|---|---|---|---|
| brain **emits** | `wicked.brain.initialized` | `wicked.brain.index.initialized` | `smaht/_bus_consumers.py` |
| brain **emits** | `wicked.brain.consolidated` | `wicked.brain.index.consolidated` | `smaht/_bus_consumers.py` |
| brain **emits** | `wicked.config.updated` | `wicked.brain.config.updated` | `smaht/_bus_consumers.py` |
| brain **consumes** | `wicked.fact.extracted` | `wicked.garden.fact.extracted` | garden **owns + emits** it |

## Also
Brain's other own events migrated for grammar consistency (no external consumer today): `memory.*`, `schema.migrated`, `synonym.updated`, `tag.backfilled`, `search.executed`, `chunk.*`, `link.*`, `wiki.verified`, `article.compiled`, `query.executed`, `server.started`, `index.{reindexed,reonboarded,purged}`. Generic bus-doc example names (`wicked.agent.dispatched`, `wicked.thing.happened`, `wicked.run.completed`, …) left untouched — illustrations, not brain's catalog.

## Verify
- `node --test` → **443 passed**
- Adversarially verified: pinned edges match garden byte-for-byte, no doc example clobbered, no live 3-seg own event, all rename-forms covered

**Merge order:** land together with wicked-garden#973 + wicked-core#15 (the 4-seg lockstep). Rebase onto main after the brain colon-fix (#86) merges, since both touch skill files (disjoint lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpniabdmx6H4HsjLTjFd1x