### PR TITLE
docs: refresh narrative — dash skill identity, apex domain, 4-seg event grammar

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,31 +69,31 @@ Skills are SKILL.md files installed into your CLI's skills directory by the inst
 ```mermaid
 graph LR
     subgraph Inline["Inline (runs in conversation)"]
-        read["wicked-brain:read<br/>progressive depth 0/1/2"]
-        status["wicked-brain:status<br/>health + convergence debt + hotspots"]
-        memory["wicked-brain:memory<br/>working/episodic/semantic tiers"]
-        confirm["wicked-brain:confirm<br/>strengthen/weaken link confidence"]
-        synonyms["wicked-brain:synonyms<br/>manage search synonym map"]
-        init["wicked-brain:init<br/>structure → server → ingest"]
-        server["wicked-brain:server<br/>start/check/stop"]
-        configure["wicked-brain:configure<br/>writes CLAUDE.md / GEMINI.md"]
-        update["wicked-brain:update<br/>npm check + reinstall"]
-        batch["wicked-brain:batch<br/>generates bulk scripts"]
-        lsp["wicked-brain:lsp<br/>LSP queries via JSON-RPC"]
-        context["wicked-brain:context<br/>hot-path prompt enrichment (inline)"]
+        read["wicked-brain-read<br/>progressive depth 0/1/2"]
+        status["wicked-brain-status<br/>health + convergence debt + hotspots"]
+        memory["wicked-brain-memory<br/>working/episodic/semantic tiers"]
+        confirm["wicked-brain-confirm<br/>strengthen/weaken link confidence"]
+        synonyms["wicked-brain-synonyms<br/>manage search synonym map"]
+        init["wicked-brain-init<br/>structure → server → ingest"]
+        server["wicked-brain-server<br/>start/check/stop"]
+        configure["wicked-brain-configure<br/>writes CLAUDE.md / GEMINI.md"]
+        update["wicked-brain-update<br/>npm check + reinstall"]
+        batch["wicked-brain-batch<br/>generates bulk scripts"]
+        lsp["wicked-brain-lsp<br/>LSP queries via JSON-RPC"]
+        context["wicked-brain-context<br/>hot-path prompt enrichment (inline)"]
     end
 
     subgraph Subagent["Subagent (isolated worker)"]
-        ingest["wicked-brain:ingest<br/>chunk + index source files"]
-        search["wicked-brain:search<br/>synonym expansion + parallel search"]
-        compile["wicked-brain:compile<br/>persona-driven synthesis + consensus"]
-        query["wicked-brain:query<br/>search → read → answer"]
-        lint["wicked-brain:lint<br/>links · orphans · confidence · synonyms"]
-        enhance["wicked-brain:enhance<br/>fill gaps with inferred content"]
-        retag["wicked-brain:retag<br/>backfill synonym tags"]
-        consolidate["wicked-brain:consolidate<br/>archive · promote · merge · synonym map"]
-        onboard["wicked-brain:onboard<br/>project-understanding pipeline"]
-        teardown["wicked-brain:session-teardown<br/>capture session learnings"]
+        ingest["wicked-brain-ingest<br/>chunk + index source files"]
+        search["wicked-brain-search<br/>synonym expansion + parallel search"]
+        compile["wicked-brain-compile<br/>persona-driven synthesis + consensus"]
+        query["wicked-brain-query<br/>search → read → answer"]
+        lint["wicked-brain-lint<br/>links · orphans · confidence · synonyms"]
+        enhance["wicked-brain-enhance<br/>fill gaps with inferred content"]
+        retag["wicked-brain-retag<br/>backfill synonym tags"]
+        consolidate["wicked-brain-consolidate<br/>archive · promote · merge · synonym map"]
+        onboard["wicked-brain-onboard<br/>project-understanding pipeline"]
+        teardown["wicked-brain-session-teardown<br/>capture session learnings"]
     end
 ```
 
@@ -237,7 +237,7 @@ Uses `fs.watch({ recursive: true })` on macOS and Windows. Falls back to 3-secon
 
 ## Component: LSP Client
 
-`wicked-brain:lsp` provides code intelligence by connecting to language servers via JSON-RPC over stdio. No additional npm dependencies — the JSON-RPC layer is hand-rolled.
+`wicked-brain-lsp` provides code intelligence by connecting to language servers via JSON-RPC over stdio. No additional npm dependencies — the JSON-RPC layer is hand-rolled.
 
 ```mermaid
 sequenceDiagram
@@ -273,7 +273,7 @@ Language servers are auto-installed on first use if not found in PATH. Supported
 ├── wiki/
 │   ├── concepts/                 # Synthesized articles about specific concepts
 │   ├── topics/                   # Broader topic articles
-│   └── projects/                 # Per-project onboarding articles (from wicked-brain:onboard)
+│   └── projects/                 # Per-project onboarding articles (from wicked-brain-onboard)
 ├── _meta/
 │   ├── config.json               # Brain path, server port (written by server on startup)
 │   ├── log.jsonl                 # Append-only event log
@@ -297,7 +297,7 @@ Language servers are auto-installed on first use if not found in PATH. Supported
 flowchart TD
     Source["Source file<br/>(PDF · DOCX · MD · code · image)"]
     Raw["raw/<br/>(original, untouched)"]
-    Ingest["wicked-brain:ingest<br/>(subagent)"]
+    Ingest["wicked-brain-ingest<br/>(subagent)"]
     TextSplit["Text: split on headings<br/>or 800-word windows"]
     BinarySplit["Binary: LLM reads via vision<br/>writes structured chunks"]
     Chunks["chunks/extracted/<br/>(YAML frontmatter + content)"]
@@ -319,9 +319,9 @@ flowchart TD
 ```mermaid
 flowchart TD
     Q["User question"]
-    Search["wicked-brain:search<br/>(parallel workers per brain)"]
+    Search["wicked-brain-search<br/>(parallel workers per brain)"]
     Results["Ranked results<br/>(depth 0: one-line summaries)"]
-    Read["wicked-brain:read<br/>(depth 1/2 on relevant hits)"]
+    Read["wicked-brain-read<br/>(depth 1/2 on relevant hits)"]
     Follow["Follow [[backlinks]]<br/>and typed relationships"]
     Synthesize["Synthesize answer<br/>with source citations"]
 
@@ -380,7 +380,7 @@ graph TB
     CB -->|"parents (inherited)"| TB
     CB -->|"links (peer)"| PB
 
-    Search["wicked-brain:search<br/>(one subagent per accessible brain)"]
+    Search["wicked-brain-search<br/>(one subagent per accessible brain)"]
     Search --> PB
     Search --> TB
     Search --> CB

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -63,7 +63,7 @@ There's nothing to deploy, no API keys to configure, no service to maintain. A d
 npx wicked-brain
 ```
 
-Skills are installed into their AI CLI. The first time they invoke `wicked-brain:init`, it handles everything in one shot: creates the brain directory structure, starts the background server (on a free port — no port configuration required), and immediately ingests the current project. By the time init finishes, the brain is queryable. The server auto-reindexes when files change.
+Skills are installed into their AI CLI. The first time they invoke `wicked-brain-init`, it handles everything in one shot: creates the brain directory structure, starts the background server (on a free port — no port configuration required), and immediately ingests the current project. By the time init finishes, the brain is queryable. The server auto-reindexes when files change.
 
 **What the team manages:**
 - A directory of markdown files (git-committable, human-readable)
@@ -142,7 +142,7 @@ wicked-brain includes an LSP (Language Server Protocol) client. This means your 
 ```
 Agent asks: "What does this function return?"
      ↓
-wicked-brain:lsp → starts language server if not running
+wicked-brain-lsp → starts language server if not running
      ↓
 Sends textDocument/hover request
      ↓
@@ -225,7 +225,7 @@ Even the worst case (Lead Developer, 19x) outperforms the naive approach by an o
 ## The Stack Comparison
 
 ```
-Traditional RAG Stack:              wicked-brain:
+Traditional RAG Stack:              wicked-brain-
 ─────────────────────               ──────────────
 Embedding model API                 (nothing)
 Vector database service             SQLite file
@@ -250,7 +250,7 @@ Opaque retrieval                    Human-readable markdown
 
 **Week 2:** The team starts querying. "What does our brain say about the SLA policy?" Results are instant, cited, and traceable to source documents.
 
-**Week 3:** Someone runs `wicked-brain:compile`. The brain generates wiki articles that synthesize scattered information into coherent concepts. These articles become the team's reference material.
+**Week 3:** Someone runs `wicked-brain-compile`. The brain generates wiki articles that synthesize scattered information into coherent concepts. These articles become the team's reference material.
 
 **Week 4:** A new team member joins. Instead of reading 50 docs, they ask the brain. The onboarding guide the brain writes cites the same source docs — but organized around what a newcomer actually needs to know.
 

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -225,7 +225,7 @@ Even the worst case (Lead Developer, 19x) outperforms the naive approach by an o
 ## The Stack Comparison
 
 ```
-Traditional RAG Stack:              wicked-brain-
+Traditional RAG Stack:              wicked-brain:
 ─────────────────────               ──────────────
 Embedding model API                 (nothing)
 Vector database service             SQLite file

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ wicked-brain gives your AI coding CLI a persistent, searchable knowledge base bu
 
 Works with **Claude Code**, **Gemini CLI**, **Copilot CLI**, **Cursor**, **Codex**, **Kiro**, and **Antigravity**.
 
-> **Status:** v0.17.2, published to npm as [`wicked-brain`](https://www.npmjs.com/package/wicked-brain).
+> **Status:** v0.18.1, published to npm as [`wicked-brain`](https://www.npmjs.com/package/wicked-brain).
 > Actively developed (JS). This is a **bridge-period adapter** — its memory and knowledge role is
 > destined to fold into [wicked-estate](https://github.com/mikeparcewski/wicked-estate).
 >
@@ -20,7 +20,7 @@ Works with **Claude Code**, **Gemini CLI**, **Copilot CLI**, **Cursor**, **Codex
 > explicit, confidence-scored `[[backlinks]]` instead of opaque embeddings — every claim traces to a
 > source file, and the agent (not a vector index) does the reasoning.
 
-wicked-brain is the **bridge-period memory** of the [wicked-* foundation](https://we.wickedagile.com):
+wicked-brain is the **bridge-period memory** of the [wicked-* foundation](https://wickedagile.com):
 a local-first stack for AI coding agents anchored by
 [wicked-estate](https://github.com/mikeparcewski/wicked-estate) (the code graph), with
 [wicked-core](https://github.com/mikeparcewski/wicked-core) (the runtime),
@@ -64,12 +64,12 @@ A lightweight background server handles the one thing that needs a database: ful
 │     Your AI CLI (Claude / Gemini / ...) │       │ Browser (you)        │
 │                                         │       │ http://localhost/…   │
 │  Skills:                                │       │ Search · Wiki viewer │
-│    wicked-brain:ingest   → add sources  │       └──────────┬───────────┘
-│    wicked-brain:search   → find content │                  │ GET /
-│    wicked-brain:query    → ask questions│                  ▼
-│    wicked-brain:compile  → build wiki   │       ┌──────────────────────┐
-│    wicked-brain:lint     → check quality│       │  Viewer HTML         │
-│    wicked-brain:ui       → open viewer  │       └──────────────────────┘
+│    wicked-brain-ingest   → add sources  │       └──────────┬───────────┘
+│    wicked-brain-search   → find content │                  │ GET /
+│    wicked-brain-query    → ask questions│                  ▼
+│    wicked-brain-compile  → build wiki   │       ┌──────────────────────┐
+│    wicked-brain-lint     → check quality│       │  Viewer HTML         │
+│    wicked-brain-ui       → open viewer  │       └──────────────────────┘
 │                                         │
 │  Your agent uses its own tools:         │
 │  Read, Write, Grep — no special APIs    │
@@ -134,7 +134,7 @@ Every running brain server serves a read-only HTML viewer at `GET /`. Open `http
 - **Header actions** — refresh (re-detect mode + re-index from disk) and delete (purge content; typed confirmation required).
 - **Read-only mode** — start the server with `--read-only` and destructive actions return 403; the viewer greys out the buttons and tells you why.
 
-Or let an agent do it: say *"open the brain viewer"* and the `wicked-brain:ui` skill resolves the brain, health-checks the server, and launches your default browser.
+Or let an agent do it: say *"open the brain viewer"* and the `wicked-brain-ui` skill resolves the brain, health-checks the server, and launches your default browser.
 
 The viewer has no auth. It's localhost-only, same-machine trust.
 
@@ -155,35 +155,35 @@ The viewer has no auth. It's localhost-only, same-machine trust.
 
 | Skill | What it does |
 |---|---|
-| `wicked-brain:init` | Set up a new brain — creates structure, starts the server, and ingests your project in one shot |
-| `wicked-brain:migrate` | Migrate a legacy flat brain at `~/.wicked-brain/` into the per-project layout |
-| `wicked-brain:ingest` | Add source files — text extracted deterministically, binary docs read via LLM vision |
-| `wicked-brain:search` | Parallel search across your brain and linked brains |
-| `wicked-brain:read` | Progressive loading: depth 0 (stats), depth 1 (summary), depth 2 (full content) |
-| `wicked-brain:query` | Answer questions with source citations |
-| `wicked-brain:compile` | Synthesize wiki articles from chunks |
-| `wicked-brain:lint` | Find broken links, orphan chunks, inconsistencies, tag synonyms, low-confidence links; auto-fix where possible |
-| `wicked-brain:enhance` | Identify and fill knowledge gaps with inferred content |
-| `wicked-brain:memory` | Store and recall experiential learnings across sessions (working / episodic / semantic tiers) |
-| `wicked-brain:status` | Brain health, stats, convergence debt detection, contradiction hotspots |
-| `wicked-brain:confirm` | Confirm or contradict a brain link — adjusts confidence score and tracks evidence |
-| `wicked-brain:synonyms` | Manage search synonym mappings; auto-suggest from search misses and tag frequency |
-| `wicked-brain:server` | Manage the background search server (auto-triggered) |
-| `wicked-brain:configure` | Write brain-aware context into your CLI's config (CLAUDE.md, GEMINI.md, etc.) |
-| `wicked-brain:batch` | Generate scripts for bulk operations — avoids burning context on repetitive tool calls |
-| `wicked-brain:retag` | Backfill synonym-expanded tags across all chunks for better search recall |
-| `wicked-brain:update` | Check npm for updates and reinstall skills across all detected CLIs |
-| `wicked-brain:lsp` | Universal code intelligence via LSP — hover, go-to-definition, diagnostics, completions |
-| `wicked-brain:graph` | Code-relationship graph — blast radius, callers, lineage — backed by a static code graph |
-| `wicked-brain:ui` | Open the read-only browser viewer — Material-styled Search + Wiki tabs over `http://localhost:<port>/` |
-| `wicked-brain:context` | Surface relevant brain knowledge for the current prompt — runs inline on the hot path to enrich what you're working on |
-| `wicked-brain:onboard` | Full project-understanding pipeline — scans the repo, investigates from multiple perspectives, and builds the support wiki |
-| `wicked-brain:session-teardown` | Capture session learnings — decisions, patterns, gotchas, discoveries — as brain memories before a session ends |
-| `wicked-brain:consolidate` | Multi-pass brain maintenance — archive noise, promote patterns, merge duplicates, and rebuild the synonym map |
+| `wicked-brain-init` | Set up a new brain — creates structure, starts the server, and ingests your project in one shot |
+| `wicked-brain-migrate` | Migrate a legacy flat brain at `~/.wicked-brain/` into the per-project layout |
+| `wicked-brain-ingest` | Add source files — text extracted deterministically, binary docs read via LLM vision |
+| `wicked-brain-search` | Parallel search across your brain and linked brains |
+| `wicked-brain-read` | Progressive loading: depth 0 (stats), depth 1 (summary), depth 2 (full content) |
+| `wicked-brain-query` | Answer questions with source citations |
+| `wicked-brain-compile` | Synthesize wiki articles from chunks |
+| `wicked-brain-lint` | Find broken links, orphan chunks, inconsistencies, tag synonyms, low-confidence links; auto-fix where possible |
+| `wicked-brain-enhance` | Identify and fill knowledge gaps with inferred content |
+| `wicked-brain-memory` | Store and recall experiential learnings across sessions (working / episodic / semantic tiers) |
+| `wicked-brain-status` | Brain health, stats, convergence debt detection, contradiction hotspots |
+| `wicked-brain-confirm` | Confirm or contradict a brain link — adjusts confidence score and tracks evidence |
+| `wicked-brain-synonyms` | Manage search synonym mappings; auto-suggest from search misses and tag frequency |
+| `wicked-brain-server` | Manage the background search server (auto-triggered) |
+| `wicked-brain-configure` | Write brain-aware context into your CLI's config (CLAUDE.md, GEMINI.md, etc.) |
+| `wicked-brain-batch` | Generate scripts for bulk operations — avoids burning context on repetitive tool calls |
+| `wicked-brain-retag` | Backfill synonym-expanded tags across all chunks for better search recall |
+| `wicked-brain-update` | Check npm for updates and reinstall skills across all detected CLIs |
+| `wicked-brain-lsp` | Universal code intelligence via LSP — hover, go-to-definition, diagnostics, completions |
+| `wicked-brain-graph` | Code-relationship graph — blast radius, callers, lineage — backed by a static code graph |
+| `wicked-brain-ui` | Open the read-only browser viewer — Material-styled Search + Wiki tabs over `http://localhost:<port>/` |
+| `wicked-brain-context` | Surface relevant brain knowledge for the current prompt — runs inline on the hot path to enrich what you're working on |
+| `wicked-brain-onboard` | Full project-understanding pipeline — scans the repo, investigates from multiple perspectives, and builds the support wiki |
+| `wicked-brain-session-teardown` | Capture session learnings — decisions, patterns, gotchas, discoveries — as brain memories before a session ends |
+| `wicked-brain-consolidate` | Multi-pass brain maintenance — archive noise, promote patterns, merge duplicates, and rebuild the synonym map |
 
 ## Code Graph (offline / air-gapped)
 
-`wicked-brain:graph` (blast radius, callers, lineage) is backed by the
+`wicked-brain-graph` (blast radius, callers, lineage) is backed by the
 [`@colbymchenry/codegraph`](https://www.npmjs.com/package/@colbymchenry/codegraph)
 CLI. By **default** the brain resolves that CLI by shelling out to
 `npx @colbymchenry/codegraph` — which **fetches from the npm registry and will
@@ -238,7 +238,7 @@ When you search, wicked-brain dispatches parallel search agents across all acces
 
 ## Per-Project Brains
 
-**Each project gets its own brain.** `wicked-brain:init` creates a brain under
+**Each project gets its own brain.** `wicked-brain-init` creates a brain under
 `~/.wicked-brain/projects/{project-name}/` by default, where `{project-name}`
 is the basename of your current working directory. This keeps unrelated
 codebases, clients, and research domains from crowding a single index — and
@@ -257,7 +257,7 @@ on each other. A supervising "meta-brain" can watch `~/.wicked-brain/projects/*`
 and federate queries across all of them via `brain.json` links.
 
 If you really want one brain for everything, you can pass a custom path to
-`wicked-brain:init` — but you'll fight the index as it grows.
+`wicked-brain-init` — but you'll fight the index as it grows.
 
 ## What's on Disk
 
@@ -303,7 +303,7 @@ Plain Node.js server (SQLite FTS5 + file watcher + optional LSP client + HTML vi
 Compare that to a typical RAG stack:
 
 ```
-Typical RAG:                           wicked-brain:
+Typical RAG:                           wicked-brain-
 - Embedding model API                 - SQLite (one file)
 - Vector database (Pinecone/Weaviate) - Markdown files
 - Chunking pipeline                   - Agent's native tools

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Plain Node.js server (SQLite FTS5 + file watcher + optional LSP client + HTML vi
 Compare that to a typical RAG stack:
 
 ```
-Typical RAG:                           wicked-brain-
+Typical RAG:                           wicked-brain:
 - Embedding model API                 - SQLite (one file)
 - Vector database (Pinecone/Weaviate) - Markdown files
 - Chunking pipeline                   - Agent's native tools

--- a/docs/specs/2026-04-17-wiki-staleness-detection.md
+++ b/docs/specs/2026-04-17-wiki-staleness-detection.md
@@ -166,7 +166,7 @@ no new deps.
 
 ## Open questions
 
-- Should `verify_wiki` emit a `wicked.wiki.verified` bus event? Leaning
+- Should `verify_wiki` emit a `wicked.brain.wiki.verified` bus event? Leaning
   yes, fire-once-per-scan (not per-article) to avoid flooding the bus on
   a 200-article brain. Deferred until the bus naming pattern review.
 - Should `missing` distinguish "chunk was never ingested" from "chunk was


### PR DESCRIPTION
## What

Surgical documentation refresh to align wicked-brain's docs with the current ecosystem conventions. No code, no site (this repo is a library/tool with correctly no Pages).

## Changes

- **Skill identity → dash form.** Converted every skill reference from the colon shorthand (`wicked-brain:search`) to the canonical dash install identity (`wicked-brain-search`) across `README.md`, `HOW-IT-WORKS.md`, and `ARCHITECTURE.md`. This matches the frontmatter `name`/directory and resolves on all 7 supported CLIs — the colon form breaks non-Claude hosts that rewrite `:`→`-` (per CLAUDE.md). None of the converted references were sanctioned `Skill(...)` / `/slash` / `subagent_type` dispatch forms.
- **Version.** README status bumped `v0.17.2` → `v0.18.1` to match `package.json`.
- **Family/foundation link.** The `wicked-* foundation` phrase now links to the apex portfolio `wickedagile.com` instead of the estate product subdomain `we.wickedagile.com`.
- **Event grammar.** The proposed bus event in the wiki-staleness spec is now 4-segment `wicked.brain.wiki.verified` (was 3-seg `wicked.wiki.verified`), matching the repo's own grammar (`wicked.garden.fact.extracted`).

## Verification

- `npm test` → 453 pass, 0 fail.
- ASCII box-art and Mermaid diagram alignment preserved (colon and dash are equal width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpniabdmx6H4HsjLTjFd1x