### PR TITLE
feat(domain): wire the real estate CLI seam (phase-2) — requirement/rule_confidence/out_edges + vocabulary

### DIFF
--- a/server/lib/domain-config.mjs
+++ b/server/lib/domain-config.mjs
@@ -17,8 +17,11 @@ export const DEFAULT_CONFIG = Object.freeze({
     structural_kinds: Object.freeze(["field", "variable"]),
     // Estate object-kinds naming entities verbatim (mainframe/IaC only). Empty for a modern repo.
     estate_behavior_kinds: Object.freeze([]),
-    // Edge kinds that make a node "active": a `module` with zero of these is excluded from the denominator.
-    behavior_edge_kinds: Object.freeze(["calls", "uses", "references"]),
+    // Edge kinds that make a node "active": a `module` with zero of these is excluded from the
+    // denominator. Lower-cased estate EdgeKind names (normalizeNode lower-cases estate's PascalCase);
+    // includes `imports` so a module that depends on others counts as live (a module's out-edges are
+    // Imports/Contains, not Calls), plus call/reference/instantiate for functions/methods.
+    behavior_edge_kinds: Object.freeze(["calls", "references", "imports", "instantiates"]),
     // Confidence at/above which a rule annotation counts as RESOLVED.
     resolve_threshold: 0.75,
   }),

--- a/server/lib/estate-client.mjs
+++ b/server/lib/estate-client.mjs
@@ -106,7 +106,10 @@ export class EstateCliClient {
   }
 
   list_nodes({ kinds } = {}) {
-    const args = ["nodes", "--json"];
+    // `--semantics` enriches each node with requirement/requirement_validated/rule_confidence/
+    // out_edges (from estate's semantics + annotation + edge stores) — the fields the coverage
+    // classifier needs. Without it every node would classify as unaccounted (coverage never 1.0).
+    const args = ["nodes", "--json", "--semantics"];
     if (kinds?.length === 1) args.push("--kind", kinds[0]);
     let nodes = this.#json(args) ?? [];
     if (kinds?.length > 1) nodes = nodes.filter((n) => kinds.includes(n.kind));
@@ -149,15 +152,21 @@ export class EstateCliClient {
   }
 }
 
-/** Coerce a raw estate `nodes --json` row into the interface Node shape. */
+/** Coerce a raw estate `nodes --json` row into the interface Node shape.
+ *
+ * estate emits `kind` and edge kinds as PascalCase enum Debug names (`Function`,
+ * `Module`, `Calls`, `Imports`, …); brain's config kind-sets are lowercase. Lower-case
+ * them HERE — the estate→interface boundary — so a single adapter reconciles the whole
+ * vocabulary and the fixture client (already lowercase) passes through unchanged. */
 export function normalizeNode(n) {
+  const lc = (s) => (s == null ? null : String(s).toLowerCase());
   return {
     symbol_id: n.symbol_id,
     name: n.name ?? null,
-    kind: n.kind ?? null,
+    kind: lc(n.kind),
     file: n.file ?? "",
     app: n.app ?? appFromFile(n.file ?? ""),
-    out_edges: n.out_edges ?? [],
+    out_edges: (n.out_edges ?? []).map((e) => String(e).toLowerCase()),
     requirement: n.requirement ?? null,
     requirement_validated: n.requirement_validated ?? false,
     rule_confidence: n.rule_confidence ?? null,

--- a/server/test/estate-client.test.mjs
+++ b/server/test/estate-client.test.mjs
@@ -1,0 +1,63 @@
+// Contract test for the PRODUCTION estate seam (EstateCliClient / normalizeNode).
+// The fixture client is exercised elsewhere; this locks the mapping from estate's
+// REAL `nodes --json --semantics` output onto the interface Node shape, and proves
+// that shape flows through the coverage classifier — the wiring-phase blocker was
+// that estate emits no flat requirement/rule_confidence/out_edges, so every node
+// classified as "unaccounted" and coverage could never reach 1.0.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeNode, appFromFile } from "../lib/estate-client.mjs";
+import { classifyNode } from "../lib/coverage.mjs";
+
+// A node exactly as `wicked-estate nodes --json --semantics` emits it.
+const estateSemanticsRow = {
+  symbol_id: "sym::pay::charge",
+  name: "charge",
+  kind: "Function", // estate emits PascalCase NodeKind Debug names
+  file: "src/pay/charge.js",
+  line: 12,
+  signature: "charge(amount)",
+  annotation_summary: { count: 1, by_type: { business_rule: 1 }, has_advisory: false },
+  annotations: [{ type: "business_rule", key: "business_rule", value: "…", confidence: 0.91 }],
+  requirement: "REQ-PAY-001",
+  requirement_validated: true,
+  rule_confidence: 0.91,
+  out_edges: ["Calls", "Imports"], // estate EdgeKind Debug names
+};
+
+test("normalizeNode: maps the estate `--semantics` node shape onto the interface Node (lower-casing PascalCase kinds)", () => {
+  const n = normalizeNode(estateSemanticsRow);
+  assert.equal(n.symbol_id, "sym::pay::charge");
+  assert.equal(n.kind, "function"); // PascalCase → lower-case to match brain's config kind-sets
+  assert.equal(n.rule_confidence, 0.91);
+  assert.equal(n.requirement, "REQ-PAY-001");
+  assert.equal(n.requirement_validated, true);
+  assert.deepEqual(n.out_edges, ["calls", "imports"]); // lower-cased to match behavior_edge_kinds
+  assert.equal(n.app, "src"); // leading path segment
+});
+
+test("estate seam end-to-end: a --semantics node classifies as RESOLVED, not unaccounted", () => {
+  // The exact blocker: without these fields the classifier saw every node as unaccounted.
+  const n = normalizeNode(estateSemanticsRow);
+  assert.equal(classifyNode(n, 0.75), "resolved");
+});
+
+test("normalizeNode: a bare `nodes --json` node (no --semantics) degrades safely", () => {
+  const bare = {
+    symbol_id: "sym::x", name: "x", kind: "function", file: "a/x.js", line: 1,
+    annotation_summary: { count: 0, by_type: {}, has_advisory: false },
+  };
+  const n = normalizeNode(bare);
+  assert.equal(n.rule_confidence, null);
+  assert.equal(n.requirement, null);
+  assert.equal(n.requirement_validated, false);
+  assert.deepEqual(n.out_edges, []);
+  assert.equal(classifyNode(n, 0.75), "unaccounted");
+});
+
+test("appFromFile: derives the app from the leading path segment", () => {
+  assert.equal(appFromFile("billing/src/charge.js"), "billing");
+  assert.equal(appFromFile("./x.js"), "x.js");
+  assert.equal(appFromFile(""), "default");
+});


### PR DESCRIPTION
Phase-2 of the domain-brain: make the engines run against a **live wicked-estate**, not just the fixture client. Closes the fan-out review's disclosed wiring-phase blocker.

## The blockers
1. `EstateCliClient` read flat `requirement/requirement_validated/rule_confidence/out_edges` that estate's `nodes --json` never emitted → every node classified as unaccounted, coverage stuck at 0. (Fixed by estate PR mikeparcewski/wicked-estate#61 adding `nodes --json --semantics`; `list_nodes` now requests it.)
2. **Found here:** estate emits `kind` and edge kinds as PascalCase enum Debug names (`Function`, `Calls`, `Imports`) while brain's config is lowercase (calibrated to the *fake*). Same silent-zero-coverage failure. Fixed by lower-casing at the `normalizeNode` boundary + adding `imports` to `behavior_edge_kinds` so modules aren't all dropped.

## Verified end-to-end (real estate binary, real repo)
Indexed a 2-file fixture, annotated `charge` (business_rule conf 0.9 + validated requirement), ran brain `computeCoverage` against the live DB:
```
behavior_bearing: 3 | resolved: 1 | unaccounted: 2 | coverage: 0.3333 | gate ok? false
unaccounted: [audit, refund]   mean_confidence: 0.9
```
`charge` → resolved; unannotated → unaccounted; gate correctly denies and names the holes.

- Added the first contract test for the production seam (`normalizeNode` + flow into `classifyNode`) — the untested code the review flagged. Suite **436/436**.

Merge **after** wicked-estate#61 (brain requests `--semantics`, which estate must understand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)