### PR TITLE
docs(schema): coverage mean_confidence prose — settled → resolved

### DIFF
--- a/schemas/coverage.schema.json
+++ b/schemas/coverage.schema.json
@@ -88,7 +88,7 @@
       "type": "number",
       "minimum": 0,
       "maximum": 1,
-      "description": "Mean confidence across settled nodes, 4 dp."
+      "description": "Mean confidence across RESOLVED nodes carrying a numeric confidence, 4 dp (resolved-only, per coverage.py)."
     },
     "resolve_threshold": {
       "type": "number",


### PR DESCRIPTION
One-line description fix on `coverage.schema.json`: `mean_confidence` said "across settled nodes" but the canonical algorithm (coverage.py + the wicked-core Rust port) computes it over **RESOLVED** nodes only. Descriptive-only — no validation change. Flagged in wicked-core PR #39 review; keeps the vendored copy byte-consistent with the drift-guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpniabdmx6H4HsjLTjFd1x