### PR TITLE
chore: release v0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-brain",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-brain",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "type": "module",
   "description": "Digital brain as skills for AI coding CLIs — no vector DB, no embeddings, no infrastructure",
   "keywords": [

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-brain-server",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "type": "module",
   "description": "SQLite FTS5 search server for wicked-brain digital knowledge bases",
   "keywords": [


### PR DESCRIPTION
Version bump 0.18.1 → 0.19.0 — 20 commits landed since v0.18.1 with npm still at 0.18.1. Tag after merge triggers the npm release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128mG5hv7LYmEdkxtdRUA8b